### PR TITLE
Add instructions for submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ In order to get started:
 ```sh
 $ git clone git@github.com:yarnpkg/website.git yarn-website
 $ cd yarn-website
+$ git submodule update --init --recursive
 ```
 
 And then:


### PR DESCRIPTION
Otherwise it fails with

```
  Conversion error: Jekyll::Converters::Scss encountered an error while converting 'css/main.scss':
                    File to import not found or unreadable: bootstrap/scss/bootstrap.scss. Load path: /Users/vjeux/random/website/_sass on line 9
jekyll 3.2.1 | Error:  File to import not found or unreadable: bootstrap/scss/bootstrap.scss.
Load path: /Users/vjeux/random/website/_sass on line 9
```
