### PR TITLE
Add submodule command inside of `make init`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: start install serve i18n-upload i18n-download
 
 .DEFAULT_GOAL := start
-start: editor install serve
+start: install serve
 
 install: test-bundler
+	git submodule update --init --recursive
 	@bundle install
 
 serve: test-jekyll
@@ -16,9 +17,6 @@ crowdin-sync: test-crowdin
 ###
 # Misc stuff:
 ###
-
-editor:
-	@eval $(EDITOR) ./
 
 BUNDLE_EXISTS := $(shell command -v bundle 2> /dev/null)
 JEKYLL_EXISTS := $(shell command -v jekyll 2> /dev/null)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ In order to get started:
 ```sh
 $ git clone git@github.com:yarnpkg/website.git yarn-website
 $ cd yarn-website
-$ git submodule update --init --recursive
 ```
 
 And then:


### PR DESCRIPTION
Also remove the editor thingy. When you have emacs configured it opens a file picker but it's unclear what to do with it.
