### PR TITLE
Add "build" to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: start install serve i18n-upload i18n-download
+.PHONY: start install serve build i18n-upload i18n-download
 
 .DEFAULT_GOAL := start
 start: install serve
@@ -9,6 +9,9 @@ install: test-bundler
 
 serve: test-jekyll
 	@jekyll serve
+
+build: test-jekyll
+	@jekyll build
 
 crowdin-sync: test-crowdin
 	@crowdin-cli upload sources --auto-update -b master


### PR DESCRIPTION
`jekyll build` (to actually build the site) was missing from the Makefile.

I'm not sure how much value being able to run `make build` provides over directly running `jekyll build`, but I added it for consistency with `make serve`.
