### PR TITLE
Add redirect URLs for downloads

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ baseurl: ""
 url: "https://yarnpkg.com"
 twitter_username: yarnpkg
 github_username:  yarnpkg
+latest_version: 0.13.5
 
 exclude:
   - README.md

--- a/_redirects
+++ b/_redirects
@@ -1,8 +1,9 @@
+---
+layout: null
+---
 /downloads/:version/:file https://github.com/yarnpkg/yarn/releases/download/v:version/:file
 
 # Nice short URLs to download the latest release
-# TODO: Make a website build step that dynamically generates this _redirects 
-# file with the right URLs.
-/latest.tar.gz https://github.com/yarnpkg/yarn/releases/download/v0.13.5/kpm-v0.13.5.tar.gz
-/latest.msi https://github.com/yarnpkg/yarn/releases/download/v0.13.5/kpm-v0.13.5.msi
-/latest.deb https://github.com/yarnpkg/yarn/releases/download/v0.13.5/kpm-v0.13.5.deb
+/latest.tar.gz https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/kpm-v{{site.latest_version}}.tar.gz
+/latest.msi https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/kpm-v{{site.latest_version}}.msi
+/latest.deb https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/kpm-v{{site.latest_version}}.deb


### PR DESCRIPTION
Adds some redirect URLs for downloads, using Netlify's redirect syntax (https://www.netlify.com/docs/redirects/). These should be used for permalinks to downloads, as it avoids us being tightly coupled to Github releases.
- `/downloads/0.13.5/kpm-0.13.5.tar.gz` redirects to `https://github.com/yarnpkg/yarn/releases/download/v0.13.5/kpm-v0.13.5.tar.gz`
- `/latest.tar.gz`, `/latest.msi` and `/latest.deb` redirect to the latest download in the specified format. This is currently hard-coded, but we could build them as part of the site's build script. I imagine we'll show the latest version number on the website somewhere, so that could go in a config file and the build script could read that.

These URLs are not as clean as I would have liked, due to limitations with Netlify's redirect syntax. It's a very basic syntax with no advanced functionality. I was hoping for something like `/downloads/kpm-0.13.5.tar.gz` via a regex like `/downloads/(.+?([0-9\.]+).+)` that redirects to `https://github.com/yarnpkg/yarn/releases/download/$2/$1` to avoid the repetition of the version number in the URL, but unfortunately Netlify doesn't allow regex like regular Apache/Nginx rewrites do. Oh well.

Closes #13 
