### PR TITLE
[downloads] Automatically select correct OS based on user-agent

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,5 +25,9 @@
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha/js/bootstrap.min.js" integrity="sha256-+h0g0j7qusP72OZaLPCSZ5wjZLnoUUicoxbvrl14WxM=" crossorigin="anonymous"></script>
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/holder/2.9.4/holder.min.js" integrity="sha256-ifihHN6L/pNU1ZQikrAb7CnyMBvisKG3SUAab0F3kVU=" crossorigin="anonymous"></script>
+
+    {% for script in page.scripts %}
+      <script type="text/javascript" src="{{script}}"></script>
+    {% endfor %}
   </body>
 </html>

--- a/en/docs/install.html
+++ b/en/docs/install.html
@@ -2,6 +2,8 @@
 id: docs_install
 guide: docs_getting_started
 layout: guide
+scripts:
+  - "/js/install.js"
 ---
 
 {% include vars.html %}
@@ -16,15 +18,15 @@ layout: guide
 <div class="tabs">
   <div class="nav nav-tabs bg-faded text-xs-center">
     <ul class="nav navbar-nav nav-inline">
-      <a class="nav-item nav-link" data-toggle="tab" href="#mac">{{i18n.install_os_mac}}</a>
-      <a class="nav-item nav-link" data-toggle="tab" href="#windows">{{i18n.install_os_windows}}</a>
-      <a class="nav-item nav-link" data-toggle="tab" href="#linux">{{i18n.install_os_linux}}</a>
-      <a class="nav-item nav-link text-success" data-toggle="tab" href="#alternatives">{{i18n.install_os_alternatives}}</a>
+      <a id="mac-tab" class="nav-item nav-link" data-toggle="tab" href="#mac">{{i18n.install_os_mac}}</a>
+      <a id="windows-tab" class="nav-item nav-link" data-toggle="tab" href="#windows">{{i18n.install_os_windows}}</a> <!-- I see you Daniel. -->
+      <a id="linux-tab" class="nav-item nav-link" data-toggle="tab" href="#linux">{{i18n.install_os_linux}}</a>
+      <a id="alternatives-tab" class="nav-item nav-link text-success" data-toggle="tab" href="#alternatives">{{i18n.install_os_alternatives}}</a>
     </ul>
   </div>
 
   <div class="tab-content">
-    <div class="tab-pane bg-faded active">
+    <div id="select-platform" class="tab-pane bg-faded active">
       <p class="text-xs-center m-y-2 text-muted">
         {{i18n.install_select_platform}}
       </p>
@@ -47,7 +49,7 @@ layout: guide
 </div>
 
 {% capture issueBody %}
-**What operating system are you using:**
+**Which operating system are you using:**
 
 
 **Please describe the steps you took when trying to install Yarn and what went wrong:**

--- a/js/install.js
+++ b/js/install.js
@@ -1,0 +1,7 @@
+[
+  [/Windows/i, '#windows-tab'],
+  [/Mac OS/i, '#mac-tab'],
+  [/Linux|Ubuntu|Debian/i, '#linux-tab']
+].find(function(os) {
+  return os[0].test(navigator.userAgent) && $(os[1]).tab('show');
+});


### PR DESCRIPTION
Automatically select the correct operating system based on the user-agent.

Also swapped the order of the Windows and Mac OS tabs to get them in a rough order of market share ([~52% of developers are on Windows, ~26% on Mac OS, ~22% on Linux](https://stackoverflow.com/research/developer-survey-2016#technology-desktop-operating-system))

Closes #6
