### PR TITLE
Center hero text

### DIFF
--- a/_sass/_heros.scss
+++ b/_sass/_heros.scss
@@ -54,6 +54,7 @@
   z-index: 1;
   font-size: 2.5em;
   font-weight: 600;
+  text-align: center;
   text-transform: uppercase;
   text-shadow: 2px 3px $yarn-blue-darkest;
 }


### PR DESCRIPTION
It was slightly misaligned with some extra space on the right:

![hero1](https://cloud.githubusercontent.com/assets/91933/19178250/dac4604a-8c05-11e6-9fff-c1ab0fe49b17.PNG)

Particularly noticeable when the window size was close to the break points:
![hero2](https://cloud.githubusercontent.com/assets/91933/19178254/eae42906-8c05-11e6-9bab-b9e4da99c387.PNG)

Now it's nicer:
![hero3](https://cloud.githubusercontent.com/assets/91933/19178267/05936dc0-8c06-11e6-84be-ab26319982b2.PNG)
