### PR TITLE
Add link to Facebook page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -50,6 +50,9 @@
           <a class="nav-link" href="https://twitter.com/yarnpkg">Twitter</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="https://www.facebook.com/yarnpkg">Facebook</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="https://github.com/yarnpkg">GitHub</a>
         </li>
       </ul>


### PR DESCRIPTION
Adds a link to the Yarn Facebook page.

Note: The page is currently unpublished so you'd need to be added as an editor, advertiser, moderator or admin on the Page to see it.
