### PR TITLE
Remove subjective text about Bitbucket

### DIFF
--- a/en/docs/creating-a-package.md
+++ b/en/docs/creating-a-package.md
@@ -165,7 +165,7 @@ websites for hosting your code:
 
 - [GitHub](https://github.com)
 - [GitLab](https://about.gitlab.com/)
-- [BitBucket](https://bitbucket.org/) (Bad choice for open source projects)
+- [BitBucket](https://bitbucket.org/)
 
 These sites will allow your users to see your code, report issues, and
 contribute back. Once you have your code up somewhere you should add the


### PR DESCRIPTION
"Bad choice for open source projects" is subjective and doesn't belong in official docs. There's nothing wrong with hosting open-source projects on BitBucket.
