### PR TITLE
Add RPM instructions

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -200,7 +200,7 @@ install_intro: >
 install_select_platform: Select your platform above
 install_os_mac: macOS
 install_os_windows: Windows
-install_os_linux: Debian/Ubuntu Linux
+install_os_linux: Linux
 install_os_alternatives: Alternatives
 
 install_test: "Test that Yarn is installed by running:"

--- a/_redirects
+++ b/_redirects
@@ -4,9 +4,10 @@ layout: null
 /downloads/:version/:file https://github.com/yarnpkg/yarn/releases/download/v:version/:file
 
 # Nice short URLs to download the latest release
-/latest.tar.gz https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/kpm-v{{site.latest_version}}.tar.gz
-/latest.msi https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/kpm-v{{site.latest_version}}.msi
-/latest.deb https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/kpm-v{{site.latest_version}}.deb
+/latest.tar.gz https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/yarn-v{{site.latest_version}}.tar.gz
+/latest.msi https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/yarn-{{site.latest_version}}.msi
+/latest.deb https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/yarn_{{site.latest_version}}_all.deb
+/latest.rpm https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/yarn-{{site.latest_version}}-1.noarch.rpm
 
 {% for language in site.data.languages %}
   {% if language.enabled %}

--- a/en/docs/_installations/linux.md
+++ b/en/docs/_installations/linux.md
@@ -13,3 +13,15 @@ Then you can simply:
 ```sh
 sudo apt-get update && sudo apt-get install yarn
 ```
+
+## CentOS / Fedora / RHEL
+
+On CentOS, Fedora and RHEL, you can install Yarn via our RPM package:
+
+```sh
+wget https://yarnpkg.com/latest.rpm
+rpm -Uvh yarn-*.rpm
+```
+
+You will need to first [enable the NodeSource repository](https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora)
+as CentOS does not include Node.js in its main repository.


### PR DESCRIPTION
Adds instructions for installing from RPM package. No repository at the moment, just the RPM file. Build script for RPM package added in https://github.com/yarnpkg/yarn/pull/556

Also updated the download URLs for the various latest redirects.
