### PR TITLE
Add RPM instructions

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -200,7 +200,7 @@ install_intro: >
 install_select_platform: Select your platform above
 install_os_mac: macOS
 install_os_windows: Windows
-install_os_linux: Debian/Ubuntu Linux
+install_os_linux: Linux
 install_os_alternatives: Alternatives
 
 install_test: "Test that Yarn is installed by running:"

--- a/en/docs/_installations/linux.md
+++ b/en/docs/_installations/linux.md
@@ -13,3 +13,21 @@ Then you can simply:
 ```sh
 sudo apt-get update && sudo apt-get install yarn
 ```
+
+### CentOS / Fedora / RHEL
+
+On CentOS, Fedora and RHEL, you can install Yarn via our RPM package repository.
+```sh
+sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo
+```
+
+If you do not already have Node.js installed, you should also configure
+[the NodeSource repository](https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora):
+```sh
+curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+```
+
+Then you can simply:
+```sh
+sudo yum install yarn
+```


### PR DESCRIPTION
Adds instructions for installing from RPM package. Depends on https://github.com/yarnpkg/yarn/pull/556

Note when testing this: Currently `yum install yarn` doesn't work since I don't actually have a Yarn package in the repo (until we launch publicly), but `yum install yarn-helloworld` works to install a dummy 'hello world' project
