### PR TITLE
Document yarn outdated command

### DIFF
--- a/en/docs/cli/outdated.md
+++ b/en/docs/cli/outdated.md
@@ -4,10 +4,41 @@ guide: docs_cli
 layout: guide
 ---
 
+<p class="lead">Checks for outdated package dependencies.</p>
+
+
 ##### `yarn outdated` <a class="toc" id="toc-yarn-outdated" href="#toc-yarn-outdated"></a>
 
-Lists package dependencies organized by current version installed, the version wanted, and the latest available version.
+Lists version information for all package dependencies. This information includes the currently installed version, the desired version based on semver, and the latest available version.
+
+For example, say your `package.json` has the following dependecies listed:
+
+```js
+"dependencies": {
+  "lodash": "4.15.0",
+  "underscore": "~1.6.0"
+}
+```
+
+The command run should look something like this:
+
+```sh
+$ yarn outdated
+Package    Current Wanted Latest
+lodash     4.15.0  4.15.0 4.16.4
+underscore 1.6.0   1.6.0  1.8.3 
+✨  Done in 0.72s.
+```
 
 ##### `yarn outdated [package...]` <a class="toc" id="toc-yarn-outdated-package" href="#toc-yarn-outdated-package"></a>
 
-> ***Currently unimplemented***
+Lists version information for one or more package dependencies.
+
+For the example `package.json` shown previously, you should see the following output when checking one of the dependencies:
+
+```sh
+$ yarn outdated lodash
+Package Current Wanted Latest
+lodash  4.15.0  4.15.0 4.16.4
+✨  Done in 1.04s.
+```


### PR DESCRIPTION
Document the `yarn outdated` command. See https://github.com/yarnpkg/website/issues/62

![screen shot 2016-10-10 at 1 42 05 pm](https://cloud.githubusercontent.com/assets/691109/19250517/83ccccb8-8eef-11e6-8200-3e506efb744c.png)
