### PR TITLE
Fix cache clean docs

### DIFF
--- a/en/docs/cli/cache.md
+++ b/en/docs/cli/cache.md
@@ -9,7 +9,7 @@ layout: guide
 Yarn stores every package in a global cache in your user directory on the file
 system. `yarn cache ls` will print out every cached package.
 
-##### `yarn cache clear` <a class="toc" id="toc-yarn-cache-clear" href="#toc-yarn-cache-clear"></a>
+##### `yarn cache clean` <a class="toc" id="toc-yarn-cache-clean" href="#toc-yarn-cache-clean"></a>
 
 Running this command will clear the local cache. It will be populated again the
 next time `yarn` or `yarn install` is run.


### PR DESCRIPTION
`yarn cache clear` does not work, but `yarn cache clean` does. `clear` gives the following error:
```
% yarn cache clear
yarn cache v0.15.1
error Invalid subcommand. Try "ls, clean"
info Visit http://yarnpkg.com/en/docs/cli/cache for documentation about this command.
```