### PR TITLE
Use full key fingerprint in apt-key command

### DIFF
--- a/en/docs/_installations/linux.md
+++ b/en/docs/_installations/linux.md
@@ -4,7 +4,7 @@ On Debian or Ubuntu Linux, you can install Yarn via our Debian package
 repository. You will first need to configure the repository:
 
 ```sh
-sudo apt-key adv --keyserver pgp.mit.edu --recv 9D41F3C3
+sudo apt-key adv --keyserver pgp.mit.edu --recv 72ECF46A56B4AD39C907BBB71646B01B86E50310
 echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 ```
 


### PR DESCRIPTION
Prevents GPG short key id collision attacks. For more information,
see https://evil32.com.