### PR TITLE
Fix doc link for yarn ls

### DIFF
--- a/en/docs/cli/global.md
+++ b/en/docs/cli/global.md
@@ -22,5 +22,5 @@ Read more about the commands that can be used together with `yarn global`:
 
 - [`yarn add`](./add): add a package to use in your current package.
 - [`yarn bin`](./install): install all dependencies defined in a `package.json` file.
-- [`yarn ls`](./init): initialize for the development of a package.
+- [`yarn ls`](./ls): list installed packages.
 - [`yarn remove`](./remove): remove a package that will no longer be used in your current package.


### PR DESCRIPTION
So, either the link is wrong, or the name is wrong. I am pretty sure that this was meant to be for `yarn ls` and not `yarn init`, but let me know if that's incorrect!