### PR TITLE
[next release] Removal of Bash on Windows notice.

### DIFF
--- a/en/docs/_installations/windows.md
+++ b/en/docs/_installations/windows.md
@@ -16,6 +16,3 @@ If you use the installer you will first need to install
 ##### Install via Chocolatey
 
 A Chocolatey package is coming soon!
-
-**Note:** Yarn is currently incompatible with installation via Ubuntu on Windows awaiting a resolution to 
-<a href="https://github.com/Microsoft/BashOnWindows/issues/468">468</a>


### PR DESCRIPTION
This should be accepted whenever the next public build happens, this issue is rectified in https://github.com/yarnpkg/yarn/commit/c9415ca3d2593cf0801111b2b22a6c80b9d084c5