### PR TITLE
docs/cli: Added test command docs.

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -108,6 +108,9 @@
   - id: docs_cli_team
     path: /docs/cli/team
     tags: ["cli-team"]
+  - id: docs_cli_test
+    path: /docs/cli/test
+    tags: ["cli-test"]
   - id: docs_cli_unlink
     path: /docs/cli/unlink
     tags: ["cli-unlink"]

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -128,6 +128,7 @@ docs_cli_run: yarn run
 docs_cli_self_update: yarn self-update
 docs_cli_tag: yarn tag
 docs_cli_team: yarn team
+docs_cli_test: yarn test
 docs_cli_unlink: yarn unlink
 docs_cli_upgrade: yarn upgrade
 docs_cli_version: yarn version

--- a/en/docs/cli/test.md
+++ b/en/docs/cli/test.md
@@ -1,0 +1,49 @@
+---
+id: docs_cli_test
+guide: docs_cli
+layout: guide
+---
+
+<p class="lead">Runs the test script defined by the package.</p>
+
+##### `yarn test` <a class="toc" id="toc-yarn-test" href="#toc-yarn-test"></a>
+
+If you have defined a `scripts` object in your package, this command will run
+the specified `test` script.
+
+For example, if you have a bash script in your package, `scripts/test`:
+
+```sh
+#!/bin/bash
+
+echo "Hello, world!"
+```
+
+and the following in your `package.json`:
+
+```json
+{
+  "name": "my-tribute-package",
+  "version": "1.0.0",
+  "description": "This is not the best package in the world, this is just a tribute.",
+  "main": "index.js",
+  "author": "Yarn Contributor",
+  "license": "MIT",
+  "scripts": {
+    "test": "scripts/test"
+  }
+}
+```
+
+then running `yarn test` would yield:
+
+```sh
+$ yarn test
+yarn test v0.15.1
+$ "./scripts/test"
+Hello, world!
+✨ Done in 0.17s.
+```
+##### `yarn run test`
+
+`yarn test` is also a shortcut for `yarn run test`.


### PR DESCRIPTION
The documentation for the `test` command was missing so I decided to add it in with the first commit.

~~In the second commit, I added more information about system-wide commands not being executable by Yarn. Since it's possibly a breaking change for people coming from npm, I felt it should be proactively addressed in the docs.~~

~~The third commit just adds a missing `p.lead` tag to `run`.~~

I tried to lift the wording and formatting from other doc entries.