### PR TITLE
Corrected 'gitlub' in docs to 'github'

### DIFF
--- a/en/docs/creating-a-package.md
+++ b/en/docs/creating-a-package.md
@@ -173,10 +173,10 @@ following fields to your `package.json`:
 
 ```json
 {
-  "homepage": "https://gitlub.com/username/my-new-project",
-  "bugs": "https://gitlub.com/username/my-new-project/issues",
+  "homepage": "https://github.com/username/my-new-project",
+  "bugs": "https://github.com/username/my-new-project/issues",
   "repository": {
-    "url": "https://gitlub.com/username/my-new-project",
+    "url": "https://github.com/username/my-new-project",
     "type": "git"
   }
 }

--- a/en/docs/package-json.md
+++ b/en/docs/package-json.md
@@ -130,7 +130,7 @@ The homepage is the URL to the landing page or documentation for your package.
 
 ```json
 {
-  "bugs": "https://gitlub.com/user/repo/issues"
+  "bugs": "https://github.com/user/repo/issues"
 }
 ```
 
@@ -140,7 +140,7 @@ The URL to your project's issue tracker. This can also be something like an emai
 
 ```json
 {
-  "repository": { "type": "git", "url": "https://gitlub.com/user/repo.git" },
+  "repository": { "type": "git", "url": "https://github.com/user/repo.git" },
   "repository": "github:user/repo",
   "repository": "gitlab:user/repo",
   "repository": "bitbucket:user/repo",


### PR DESCRIPTION
Corrected all mentions of _gitlub_ in the docs to _github_. I assume this was a mistake (not a mix of Github and Gitlab!) as there are many references to Github which are spelt correctly.