### PR TITLE
i.e. → e.g.

### DIFF
--- a/en/docs/cli/add.md
+++ b/en/docs/cli/add.md
@@ -30,7 +30,7 @@ You can specify versions using one of these:
 2. `yarn add package-name@1.2.3` installs a specific version of a package from
   the registry.
 3. `yarn add package-name@tag` installs a specific
-  ["tag"]({{url_base}}/docs/cli/tag) (i.e. `beta`, `next`, or `latest`).
+  ["tag"]({{url_base}}/docs/cli/tag) (e.g. `beta`, `next`, or `latest`).
 
 In general, a package is simply a folder with code and a `package.json` file
 that describes the contents. You can refer to a package a number of different

--- a/en/docs/dependency-types.md
+++ b/en/docs/dependency-types.md
@@ -6,8 +6,8 @@ layout: guide
 
 Dependencies serve many different purposes. Some dependencies are needed to
 build your project, others are needed when your running your program. As such
-there are a number of different types of dependencies that you can have (i.e.
-`dependencies`, `devDependencies`, or `peerDependencies`).
+there are a number of different types of dependencies that you can have (e.g.
+`dependencies`, `devDependencies`, and `peerDependencies`).
 
 Your `package.json` will contain all of these dependencies:
 
@@ -35,12 +35,12 @@ are important to understand.
 ##### `dependencies` <a class="toc" id="toc-dependencies" href="#toc-dependencies"></a>
 
 These are your normal dependencies, or rather ones that you need when running
-your code (i.e. React or ImmutableJS).
+your code (e.g. React or ImmutableJS).
 
 ##### `devDependencies` <a class="toc" id="toc-devdependencies" href="#toc-devdependencies"></a>
 
 These are your development dependencies. Dependencies that you need at some
-point in the development workflow but not while running your code (i.e. Babel
+point in the development workflow but not while running your code (e.g. Babel
 or Flow).
 
 ##### `peerDependencies` <a class="toc" id="toc-peerdependencies" href="#toc-peerdependencies"></a>
@@ -59,7 +59,7 @@ Optional dependencies are just that: optional. If they fail to install, Yarn
 will still say the install process was successful.
 
 This is useful for dependencies that won't necessarily work on every machine
-and you have a fallback plan in case they are not installed (i.e. Watchman).
+and you have a fallback plan in case they are not installed (e.g. Watchman).
 
 ##### `bundledDependencies` <a class="toc" id="toc-bundleddependencies" href="#toc-bundleddependencies"></a>
 

--- a/en/docs/dependency-versions.md
+++ b/en/docs/dependency-versions.md
@@ -22,7 +22,7 @@ at various times:
   **backwards-compatible**
 
 > **Note:** There are also sometimes "labels" or "extensions" to the semver
-> format that mark things like pre-releases or betas (i.e. `2.0.0-beta.3`)
+> format that mark things like pre-releases or betas (e.g. `2.0.0-beta.3`)
 
 When developers talk about two semver versions being "compatible" with one
 another they are referring to the **backwards-compatible** changes (`minor` and
@@ -82,7 +82,7 @@ means _"Less than `2.0.0` **or** greater than `3.1.4`"_.
 
 #### Pre-release tags <a class="toc" id="toc-pre-release-tags" href="#toc-pre-release-tags"></a>
 
-Versions can also have **pre-release tags** (i.e. `3.1.4-beta.2`). If a
+Versions can also have **pre-release tags** (e.g. `3.1.4-beta.2`). If a
 comparator includes a version with a pre-release tag it will only match against
 versions that have the same `major.minor.patch` version.
 
@@ -98,8 +98,8 @@ behavior is useful.
 
 ##### Hyphen Ranges <a class="toc" id="toc-hyphen-ranges" href="#toc-hyphen-ranges"></a>
 
-Hyphen ranges (i.e. `2.0.0 - 3.1.4`) specify an _inclusive_ set. If part of the
-version is left out (i.e. `0.4` or `2`) then they are filled in with zeroes.
+Hyphen ranges (e.g. `2.0.0 - 3.1.4`) specify an _inclusive_ set. If part of the
+version is left out (e.g. `0.4` or `2`) then they are filled in with zeroes.
 
 | Version range   | Expanded version range |
 | --------------- | ---------------------- |

--- a/en/docs/yarn-lock.md
+++ b/en/docs/yarn-lock.md
@@ -45,6 +45,6 @@ break something.
 
 ### Check into source control <a class="toc" id="toc-check-into-source-control" href="#toc-check-into-source-control"></a>
 
-All `yarn.lock` files should be checked into source control (i.e. git or
+All `yarn.lock` files should be checked into source control (e.g. git or
 mercurial). This allows Yarn to install the same exact dependency tree across
 all machines, whether it be your coworker's laptop or a CI server.


### PR DESCRIPTION
incomplete sets of examples should be marked 'e.g.' not 'i.e.'