### PR TITLE
Adding info that this is a JS package manager

### DIFF
--- a/en/docs/getting-started.md
+++ b/en/docs/getting-started.md
@@ -4,7 +4,7 @@ guide: docs_getting_started
 layout: guide
 ---
 
-Yarn is a package manager for your code. It allows you to use and share code
+Yarn is a package manager for your JavaScript code. It allows you to use and share code
 with other developers from around the world. Yarn does this quickly, securely,
 and reliably so you don't ever have to worry.
 


### PR DESCRIPTION
There is no mention that Yarn is a JS package manager on the homepage at all, but at least it should be mentioned in the Getting Started section.