### PR TITLE
Specify role of <a> dropdown

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -30,7 +30,7 @@
 
       <ul class="nav navbar-nav pull-lg-right">
         <li class="nav-item dropdown">
-          <a id="dropdownNavLanguage" class="nav-link dropdown-toggle"  href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a id="dropdownNavLanguage" class="nav-link dropdown-toggle" role="button" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             {% include svg/language.svg class="navbar-language" %}
             {{vars_active_language.name}}
           </a>


### PR DESCRIPTION
As mentioned in Bootstrap's docs:

> If the `<a>` elements are used to act as buttons – triggering in-page functionality, rather than navigating to another document or section within the current page – they should also be given an appropriate `role="button"`.