### PR TITLE
Add link to BSD license

### DIFF
--- a/en/org/contributing.md
+++ b/en/org/contributing.md
@@ -42,4 +42,4 @@ We actively welcome your pull requests.
 ## License <a class="toc" id="toc-license" href="#toc-license"></a>
 
 By contributing to Yarn, you agree that your contributions will be licensed
-under its BSD license.
+under its [BSD license](https://github.com/yarnpkg/yarn/blob/master/LICENSE).


### PR DESCRIPTION
This link is also in the footer template, but it doesn't hurt to make it easier to find by including the link where it is referenced inline on the contributing page.