### PR TITLE
Add path setup to installation documentation

### DIFF
--- a/en/docs/_installations/alternatives.md
+++ b/en/docs/_installations/alternatives.md
@@ -20,3 +20,13 @@ Once you have npm installed you can run:
 ```sh
 npm install --global yarn
 ```
+
+### Path Setup
+
+#### Unix/Linux/macOS
+
+{% include_relative _installations/unix_path_setup.md %}
+
+#### Windows
+
+{% include_relative _installations/windows_path_setup.md %}

--- a/en/docs/_installations/linux.md
+++ b/en/docs/_installations/linux.md
@@ -49,3 +49,7 @@ On Solus, you can install yarn via the Solus repository.
 ```sh
 sudo eopkg install yarn
 ```
+
+### Path Setup
+
+{% include_relative _installations/unix_path_setup.md %}

--- a/en/docs/_installations/mac.md
+++ b/en/docs/_installations/mac.md
@@ -4,3 +4,7 @@ You will need to first
 [install Node.js](https://nodejs.org/) if you don't already have it installed.
 
 {% include_relative _installations/tarball.md %}
+
+#### Path Setup
+
+{% include_relative _installations/unix_path_setup.md %}

--- a/en/docs/_installations/unix_path_setup.md
+++ b/en/docs/_installations/unix_path_setup.md
@@ -1,0 +1,3 @@
+You will need to set up the `PATH` environment variable in your terminal to have access to Yarn's binaries globally.
+
+Add `export PATH="$HOME/.yarn/bin:$PATH"` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)

--- a/en/docs/_installations/windows.md
+++ b/en/docs/_installations/windows.md
@@ -19,3 +19,7 @@ A Chocolatey package is coming soon!
 
 **Note:** Yarn is currently incompatible with installation via Ubuntu on Windows awaiting a resolution to 
 <a href="https://github.com/Microsoft/BashOnWindows/issues/468">468</a>
+
+#### Path Setup
+
+{% include_relative _installations/windows_path_setup.md %}

--- a/en/docs/_installations/windows_path_setup.md
+++ b/en/docs/_installations/windows_path_setup.md
@@ -1,0 +1,3 @@
+You will need to set up the `PATH` environment variable in your terminal to have access to Yarn's binaries globally.
+
+Add `set PATH=%PATH%;C:\.yarn\bin"` to your shell environment.


### PR DESCRIPTION
This adds documentation on setting up the path environment variable to provide global access to yarn's bin folder.