### PR TITLE
Added the yarn installation instructions for the Solus operating system

### DIFF
--- a/en/docs/_installations/linux.md
+++ b/en/docs/_installations/linux.md
@@ -42,3 +42,10 @@ If you use an [AUR Helper](https://wiki.archlinux.org/index.php/AUR_helpers) suc
 ```sh
 yaourt -S yarn
 ```
+
+### Solus
+
+On Solus, you can install yarn via the Solus repository.
+```sh
+sudo eopkg install yarn
+```


### PR DESCRIPTION
As yarn is now available in [Solus](https://solus-project.com) (both stable and unstable repos), I've added instructions on how our users can obtain yarn.