### PR TITLE
run brew update before install

### DIFF
--- a/en/docs/_installations/mac.md
+++ b/en/docs/_installations/mac.md
@@ -9,6 +9,7 @@ You can install Yarn through the [Homebrew package manager](http://brew.sh/).
 This will also install Node.js if it is not already installed.
 
 ```sh
+brew update
 brew install yarn
 ```
 


### PR DESCRIPTION
This might be obvious for long time OS X users, but my first attempt to install `yarn` ended up with:

```sh
$ brew install yarn
Error: No available formula with the name "yarn" 
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
Error: No formulae found in taps.
==> You haven't updated Homebrew in a while.
A formula for yarn might have been added recently.
Run `brew update` to get the latest Homebrew updates!
```

Why we should add this:

1. `brew update` before install will save us, newbies, from facing this error
1. I think it's a good practice, docs for linux that involve installation of new stuff usually start with with `sudo apt-get update` or `sudo yum update` and not with the actual `sudo apt-get install x-y` step.