### PR TITLE
Remove tarball steps from Mac OS page

### DIFF
--- a/en/docs/_installations/mac.md
+++ b/en/docs/_installations/mac.md
@@ -13,8 +13,6 @@ brew update
 brew install yarn
 ```
 
-{% include_relative _installations/tarball.md %}
-
 #### Path Setup
 
 {% include_relative _installations/unix_path_setup.md %}


### PR DESCRIPTION
Homebrew downloads the tarball and is basically better in every way. We should no longer suggest the installer or manually extracting the tarball for Mac OS users (it's fine to be in the "alternatives" tab just like for the other operating systems). Also, it's a better first impression if people go to the installation page and **don't** see a `curl | sh` 😛 