### PR TITLE
Fix yarn upgrade documentation on managing-dependencies 

### DIFF
--- a/en/docs/cli/team.md
+++ b/en/docs/cli/team.md
@@ -8,8 +8,37 @@ layout: guide
 
 ##### `yarn team` <a class="toc" id="toc-yarn-team" href="#toc-yarn-team"></a>
 
-*Oops, something went wrong!*
+yarn team is a prefix used for a number of commands create destroy, add, rm and ls
 
-This command hasn't been documented yet. Please
-send us a [pull request](https://github.com/yarnpkg/website/issues/65) on
-GitHub.
+These are to manage teams in organizations, and change team memberships. yarn team does not handle permissions for packages.
+
+Teams must always be fully qualified with the organization/scope they belong to when operating on them, separated by a colon (:). That is, if you have a developers team on a foo organization, you must always refer to that team as foo:developers in these commands.
+
+### What is a team? <a class="toc" id="toc-what-is-a-team" href="#toc-what-is-a-team"></a>
+
+Teams are sets of users that have access to a certain scope within the Organization.
+
+Organizations allow you to manage and monitor access to both new and pre-existing public and private packages through the use of teams
+
+### Commands <a class="toc" id="toc-commands" href="#toc-commands"></a>
+
+##### `yarn team create <scope:team>` <a class="toc" id="toc-yarn-team-create" href="#toc-yarn-team-create"></a>
+
+Create a new team.
+
+##### `yarn team destroy <scope:team>` <a class="toc" id="toc-yarn-team-destroy" href="#toc-yarn-team-destroy"></a>
+
+Destroys an existing team.
+
+##### `yarn team add <scope:team> <user>` <a class="toc" id="toc-yarn-team-add" href="#toc-yarn-team-add"></a>
+
+Add a user to an existing team.
+
+##### `yarn team rm <scope:team> <user>` <a class="toc" id="toc-yarn-team-rm" href="#toc-yarn-team-rm"></a>
+
+Remove a user from a team they belong to.
+
+##### `yarn team ls <scope>|<scope:team>` <a class="toc" id="toc-yarn-team-ls" href="#toc-yarn-team-ls"></a>
+
+If performed on an organization name, will return a list of existing teams under that organization. If performed on a team, it will instead return a list of all users belonging to that particular team.
+

--- a/en/docs/managing-dependencies.md
+++ b/en/docs/managing-dependencies.md
@@ -77,9 +77,7 @@ yarn add package-3@beta
 ### Upgrading a dependency <a class="toc" id="toc-upgrading-a-dependency" href="#toc-upgrading-a-dependency"></a>
 
 ```sh
-yarn upgrade [package]
-yarn upgrade [package]@[version]
-yarn upgrade [package]@[dist-tag]
+yarn upgrade
 ```
 
 This will upgrade your `package.json` and your `yarn.lock` file.


### PR DESCRIPTION
### Overview
`yarn update` doesn't take in arguments i.e. package name and semver numbers. This can be seen [here](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/upgrade.js#L13).

`export const noArguments = true;`

[here](https://github.com/yarnpkg/yarn/blob/e70cb84ebe2914d3f66142501bab2efb98ff482c/src/cli/index.js#L180)

    if (command.noArguments && args.length) {
        reporter.error(reporter.lang('noArguments'));
        reporter.info(getDocsInfo(commandName));
        process.exit(1);
    }

and [here](https://yarnpkg.com/en/docs/cli/upgrade) in the documentation that lists the syntax as 

    yarn upgrade

with no arguments.

Instead, `yarn upgrade` upgrades the entire list of packages in `package.json`. The only way of updating a new version of an existing package seems to be 

    yarn add <package-name>@version

I will add a new PR adding the workaround to the docs, as I am not sure whether this is the intended functionality of either commands, and I don't want to mash the two together