### PR TITLE
Document how to use Yarn in continuous integration systems

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -25,6 +25,8 @@
     path: /docs/installing-dependencies
   - id: docs_version_control
     path: /docs/version-control
+  - id: docs_install_ci
+    path: /docs/install_ci
 
 - id: docs_cli
   title: docs_cli_title

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -215,7 +215,9 @@ install_problems_new_issue: Open a new issue
 
 docs_install_ci: Continuous Integration
 ci_intro: >
-  Yarn can easily be used in various continuous integration systems:
+  Yarn can easily be used in various continuous integration systems. To speed up
+  builds, the the Yarn cache directory can be saved across builds.
+ci_select_platform: Select the continuous integration system you're using from the options above
 ci_circle: CircleCI
 ci_travis: Travis
 ci_appveyor: AppVeyor

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -212,3 +212,10 @@ install_problems_description: >
   through GitHub for an existing issue or open a new one.
 install_problems_search: Search for an existing issue
 install_problems_new_issue: Open a new issue
+
+docs_install_ci: Continuous Integration
+ci_intro: >
+  Yarn can easily be used in various continuous integration systems:
+ci_circle: CircleCI
+ci_travis: Travis
+ci_appveyor: AppVeyor

--- a/en/docs/_ci/appveyor.md
+++ b/en/docs/_ci/appveyor.md
@@ -7,5 +7,3 @@ install:
 cache:
  - "%LOCALAPPDATA%/Yarn"
 ```
-
-This will also save the Yarn cache directory across builds, to make your builds faster.

--- a/en/docs/_ci/appveyor.md
+++ b/en/docs/_ci/appveyor.md
@@ -1,0 +1,11 @@
+On [AppVeyor](https://www.appveyor.com/), you can install Yarn as part of your build by adding this to your `appveyor.yml`:
+
+```yml
+install:
+  - choco install yarn
+  - refreshenv
+cache:
+ - "%LOCALAPPDATA%/Yarn"
+```
+
+This will also save the Yarn cache directory across builds, to make your builds faster.

--- a/en/docs/_ci/circle.md
+++ b/en/docs/_ci/circle.md
@@ -11,5 +11,3 @@ depenencies:
   cache_directories:
     - "~/.yarn-cache"
 ```
-
-This will also save the Yarn cache directory across builds, to make your builds faster.

--- a/en/docs/_ci/circle.md
+++ b/en/docs/_ci/circle.md
@@ -1,0 +1,15 @@
+On [CircleCI](https://circleci.com/), you can install Yarn as part of your build by adding this to your `circle.yml` file:
+
+```yml
+depenencies:
+  pre:
+    # Install Yarn
+    - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+    - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+    - sudo apt-get update -qq
+    - sudo apt-get install -y -qq yarn
+  cache_directories:
+    - "~/.yarn-cache"
+```
+
+This will also save the Yarn cache directory across builds, to make your builds faster.

--- a/en/docs/_ci/travis.md
+++ b/en/docs/_ci/travis.md
@@ -1,0 +1,17 @@
+On [Travis CI](https://travis-ci.org/), you can install Yarn as part of your build by adding this to your `.travis.yml` file:
+
+```yml
+before_install:
+  # Repo for newer Node.js versions
+  - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+  # Repo for Yarn
+  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn
+cache:
+  directories:
+  - $HOME/.yarn-cache
+```
+
+This will also save the Yarn cache directory across builds, to make your builds faster.

--- a/en/docs/_ci/travis.md
+++ b/en/docs/_ci/travis.md
@@ -13,5 +13,3 @@ cache:
   directories:
   - $HOME/.yarn-cache
 ```
-
-This will also save the Yarn cache directory across builds, to make your builds faster.

--- a/en/docs/install_ci.html
+++ b/en/docs/install_ci.html
@@ -1,0 +1,29 @@
+---
+id: docs_install_ci
+guide: docs_yarn_workflow
+layout: guide
+---
+
+{% include vars.html %}
+
+{{i18n.ci_intro}}
+
+{% capture travis   %}{% include_relative _ci/travis.md   %}{% endcapture %}
+{% capture appveyor %}{% include_relative _ci/appveyor.md %}{% endcapture %}
+{% capture circle   %}{% include_relative _ci/circle.md   %}{% endcapture %}
+
+<div class="tabs">
+  <div class="nav nav-tabs bg-faded text-xs-center">
+    <ul class="nav navbar-nav nav-inline">
+      <a id="appveyor-tab" class="nav-item nav-link active" data-toggle="tab" href="#appveyor">{{i18n.ci_appveyor}}</a>
+      <a id="circle-tab" class="nav-item nav-link" data-toggle="tab" href="#circle">{{i18n.ci_circle}}</a>
+      <a id="travis-tab" class="nav-item nav-link" data-toggle="tab" href="#travis">{{i18n.ci_travis}}</a>
+    </ul>
+  </div>
+
+  <div class="tab-content">
+    <div class="tab-pane active" id="appveyor">{{ appveyor | markdownify }}</div>
+    <div class="tab-pane" id="circle">{{ circle | markdownify }}</div>
+    <div class="tab-pane" id="travis">{{ travis | markdownify }}</div>
+  </div>
+</div>

--- a/en/docs/install_ci.html
+++ b/en/docs/install_ci.html
@@ -15,14 +15,19 @@ layout: guide
 <div class="tabs">
   <div class="nav nav-tabs bg-faded text-xs-center">
     <ul class="nav navbar-nav nav-inline">
-      <a id="appveyor-tab" class="nav-item nav-link active" data-toggle="tab" href="#appveyor">{{i18n.ci_appveyor}}</a>
+      <a id="appveyor-tab" class="nav-item nav-link" data-toggle="tab" href="#appveyor">{{i18n.ci_appveyor}}</a>
       <a id="circle-tab" class="nav-item nav-link" data-toggle="tab" href="#circle">{{i18n.ci_circle}}</a>
       <a id="travis-tab" class="nav-item nav-link" data-toggle="tab" href="#travis">{{i18n.ci_travis}}</a>
     </ul>
   </div>
 
   <div class="tab-content">
-    <div class="tab-pane active" id="appveyor">{{ appveyor | markdownify }}</div>
+    <div id="select-platform" class="tab-pane bg-faded active">
+      <p class="text-xs-center m-y-2 text-muted">
+        {{i18n.ci_select_platform}}
+      </p>
+    </div>
+    <div class="tab-pane" id="appveyor">{{ appveyor | markdownify }}</div>
     <div class="tab-pane" id="circle">{{ circle | markdownify }}</div>
     <div class="tab-pane" id="travis">{{ travis | markdownify }}</div>
   </div>


### PR DESCRIPTION
Documents how to configure Yarn in AppVeyor, CircleCI, and Travis CI, including caching of the Yarn cache across builds.

The tabs are ordered alphabetically, so AppVeyor > CircleCI > Travis