### PR TITLE
documentation update for `yarn upgrade` command

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -38,6 +38,7 @@
   - id: docs_cli_add
     path: /docs/cli/add
     tags: ["cli-add"]
+    description: docs_cli_add_description
   - id: docs_cli_bin
     path: /docs/cli/bin
     tags: ["cli-bin"]
@@ -107,6 +108,7 @@
   - id: docs_cli_tag
     path: /docs/cli/tag
     tags: ["cli-tag"]
+    description: docs_cli_tag_description
   - id: docs_cli_team
     path: /docs/cli/team
     tags: ["cli-team"]
@@ -155,6 +157,8 @@
     path: /docs/dependency-types
   - id: docs_dependency_versions
     path: /docs/dependency-versions
+    tags: ["dependencies-versions"]
+    description: docs_dependency_versions_description
 
 - id: docs_configuration
   title: docs_configuration_title

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -104,6 +104,9 @@ docs_cli_description: |
 
 docs_cli_index: CLI Introduction
 docs_cli_add: yarn add
+docs_cli_add_description: |
+  When you want to use another package, you first need to add it to
+  your dependencies. Running `yarn add` installs it into your project.
 docs_cli_bin: yarn bin
 docs_cli_cache: yarn cache
 docs_cli_check: yarn check
@@ -127,6 +130,9 @@ docs_cli_remove: yarn remove
 docs_cli_run: yarn run
 docs_cli_self_update: yarn self-update
 docs_cli_tag: yarn tag
+docs_cli_tag_description: |
+  Tags are a way of publishing versions of your package with a label.
+  Users of your package can install that instead of a version number.
 docs_cli_team: yarn team
 docs_cli_test: yarn test
 docs_cli_unlink: yarn unlink
@@ -156,7 +162,11 @@ docs_dependencies_description: |
 
 docs_dependencies: Dependencies and versions
 docs_dependency_types: Types of dependencies
+
 docs_dependency_versions: Versions of dependencies
+docs_dependency_versions_description: |
+  Packages in Yarn follow Semantic Versioning, also known as “semver”. When you
+  install a new package it will be added with a semver version range.
 
 docs_configuration_title: Configuration
 docs_configuration_description: |

--- a/_includes/additional-reading.html
+++ b/_includes/additional-reading.html
@@ -22,6 +22,9 @@
       {% if page.tags contains tag %}
   <a class="list-group-item list-group-item-action" href="{{url_base}}{{page.path}}">
     <h5 class="list-group-item-heading">{{i18n[page.id]}}</h5>
+        {% if page.description %}
+    <p class="list-group-item-text text-muted">{{i18n[page.description]}}</p>
+        {% endif %}
   </a>
         {% break %}
       {% endif %}

--- a/en/docs/cli/add.md
+++ b/en/docs/cli/add.md
@@ -2,6 +2,7 @@
 id: docs_cli_add
 guide: docs_cli
 layout: guide
+description: docs_cli_add_description
 additional_reading_tags: ["dependencies"]
 ---
 

--- a/en/docs/cli/tag.md
+++ b/en/docs/cli/tag.md
@@ -1,6 +1,7 @@
 ---
 id: docs_cli_tag
 guide: docs_cli
+description: docs_cli_tag_description
 layout: guide
 ---
 

--- a/en/docs/cli/upgrade.md
+++ b/en/docs/cli/upgrade.md
@@ -30,6 +30,89 @@ success Saved 867 new dependencies.
 ✨  Done in 20.79s.
 ```
 
+##### `yarn upgrade [package]` <a class="toc" id="toc-yarn-upgrade-package" href="#toc-yarn-upgrade-package"></a>
+
+This upgrades a single named package to the version specified by the `latest` tag (potentially upgrading the package across major versions).
+
+```sh
+$ yarn upgrade d3-scale
+yarn upgrade vx.x.x
+[1/4] 🔍  Resolving packages...
+[2/4] 🚚  Fetching packages...
+[3/4] 🔗  Linking dependencies...
+[4/4] 📃  Building fresh packages...
+success Saved lockfile.
+success Saved 1 new dependency
+└─ d3-scale@1.0.3
+✨  Done in 6.10s.
+```
+
+This will update your `package.json` to look like this:
+
+```diff
+-  "d3-scale": "^0.9.3",
++  "d3-scale": "^1.0.3",
+```
+
+##### `yarn upgrade [package@version]` <a class="toc" id="toc-yarn-upgrade-package-version" href="#toc-yarn-upgrade-package-version"></a>
+
+This will upgrade (or downgrade) an installed package to the specified version. You can use any semver-valid version number or range.
+
+```sh
+$ yarn upgrade d3-scale@1.0.2
+yarn upgrade vx.x.x
+[1/4] 🔍  Resolving packages...
+[2/4] 🚚  Fetching packages...
+[3/4] 🔗  Linking dependencies...
+[4/4] 📃  Building fresh packages...
+success Saved lockfile.
+success Saved 1 new dependency
+└─ d3-scale@1.0.2
+✨  Done in 6.43s.
+```
+
+This will update your `package.json` to look like this:
+
+```diff
+-  "d3-scale": "^1.0.3",
++  "d3-scale": "^1.0.2",
+```
+
+Similarly, running
+
+##### `yarn upgrade [package@tag]` <a class="toc" id="toc-yarn-upgrade-package-tag" href="#toc-yarn-upgrade-package-tag"></a>
+
+This will upgrade a package to the version identified by `tag`. [Tag](./tag#toc-what-are-tags) names are chosen by project maintainers, typically you use this command to install an experimental or long term support release of an actively developed pacakge. The tag you choose will be the version that appears in your `package.json` file.
+
+```sh
+yarn upgrade react@next
+yarn upgrade v0.16.0
+[1/4] 🔍  Resolving packages...
+[2/4] 🚚  Fetching packages...
+[3/4] 🔗  Linking dependencies...
+[4/4] 📃  Building fresh packages...
+success Saved lockfile.
+success Saved 1 new dependency
+└─ react@15.4.0-rc.4
+✨  Done in 3.73s.
+```
+
+This will update your `package.json` to look like
+
+```diff
+-  "react": "^15.3.2",
++  "react": "next",
+```
+
+Similarly, using the `latest` tag will result in an updated `package.json` that looks like
+
+```diff
+-  "react": "^15.3.2",
++  "react": "latest",
+```
+
 Also see:
 
 - [`yarn add`](./add): add a package to use in your current package.
+- [`yarn tag`](./tag#toc-what-are-tags): What are tags?
+- [Versions of dependencies](../dependency-versions#toc-semantic-versioning): Semantic versioning

--- a/en/docs/cli/upgrade.md
+++ b/en/docs/cli/upgrade.md
@@ -2,6 +2,7 @@
 id: docs_cli_upgrade
 guide: docs_cli
 layout: guide
+additional_reading_tags: ["cli-add", "cli-tag", "dependencies-versions"]
 ---
 
 <p class="lead">Upgrades packages to their latest version based on the specified range.</p>
@@ -111,8 +112,3 @@ Similarly, using the `latest` tag will result in an updated `package.json` that 
 +  "react": "latest",
 ```
 
-Also see:
-
-- [`yarn add`](./add): add a package to use in your current package.
-- [`yarn tag`](./tag#toc-what-are-tags): What are tags?
-- [Versions of dependencies](../dependency-versions#toc-semantic-versioning): Semantic versioning

--- a/en/docs/dependency-versions.md
+++ b/en/docs/dependency-versions.md
@@ -1,6 +1,7 @@
 ---
 id: docs_dependency_versions
 guide: docs_dependencies
+description: docs_dependency_versions_description
 layout: guide
 ---
 

--- a/en/docs/managing-dependencies.md
+++ b/en/docs/managing-dependencies.md
@@ -79,7 +79,7 @@ yarn add package-3@beta
 ```sh
 yarn upgrade [package]
 yarn upgrade [package]@[version]
-yarn upgrade [package]@[dist-tag]
+yarn upgrade [package]@[tag]
 ```
 
 This will upgrade your `package.json` and your `yarn.lock` file.


### PR DESCRIPTION
Not sure if this is overkill or what, several of the onboarding docs mention this usage of `yarn upgrade` but it wasn't fleshed out in the docs at all, so i decided to add it and experimented with the behavior of the command to give folks a good idea of how it behaves in various cases.

I didn't immediately come across a documentation style guide or anything, but tried to keep things within the house style.