### PR TITLE
Fixed typo: two "the"s

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -218,7 +218,7 @@ install_problems_new_issue: Open a new issue
 docs_install_ci: Continuous Integration
 ci_intro: >
   Yarn can easily be used in various continuous integration systems. To speed up
-  builds, the the Yarn cache directory can be saved across builds.
+  builds, the Yarn cache directory can be saved across builds.
 ci_select_platform: Select the continuous integration system you're using from the options above
 ci_appveyor: AppVeyor
 ci_circle: CircleCI


### PR DESCRIPTION
There was two consecutive "the" words.