### PR TITLE
Pagefix docs workflow

### DIFF
--- a/en/docs/yarn-workflow.md
+++ b/en/docs/yarn-workflow.md
@@ -14,3 +14,4 @@ There are a few things you should know about the basic workflow:
   2. Adding/updating/removing dependencies
   3. Installing/reinstalling your dependencies
   4. Working with version control (i.e. git)
+  5. Continuous Integration

--- a/en/docs/yarn-workflow.md
+++ b/en/docs/yarn-workflow.md
@@ -8,7 +8,7 @@ Introducing a package manager into your project introduces a new workflow
 around dependencies. Yarn tries its best to stay out of your way and make each
 step of this workflow simple to understand.
 
-There are a couple things you should know about the basic workflow:
+There are a few things you should know about the basic workflow:
 
   1. Creating a new project
   2. Adding/updating/removing dependencies


### PR DESCRIPTION
Some things were a bit off on the yarn-workflow page :
1. The usage of "There are a **couple of things** you should know …" is a bit strange because there are more than a couple of things to know in the following pages. "**A few things**" would be more appropriate.
2. "**Continuous Integration**" is listed on the menu to the right but not on the list. 

This PR fixes those issues. Let me know if there's any fixes i need to do to the PR.