### PR TITLE
Add tab deep linking

### DIFF
--- a/en/docs/install-ci.html
+++ b/en/docs/install-ci.html
@@ -2,6 +2,8 @@
 id: docs_install_ci
 guide: docs_yarn_workflow
 layout: guide
+scripts:
+  - "/js/deeplink.js"
 ---
 
 {% include vars.html %}

--- a/en/docs/install.html
+++ b/en/docs/install.html
@@ -4,6 +4,7 @@ guide: docs_getting_started
 layout: guide
 scripts:
   - "/js/install.js"
+  - "/js/deeplink.js"
 ---
 
 {% include vars.html %}

--- a/js/deeplink.js
+++ b/js/deeplink.js
@@ -1,0 +1,53 @@
+/* global window, document */
+(function () {
+  var hash = window.location.hash;
+  var tabs = document.querySelector('.tabs');
+  // Check if hash exists in url and a tabs element exists in the DOM
+  if (hash && tabs) {
+    // Wrap it in a self invoking anonymous function to scope the variables
+    (function() {
+      // Check if there is a tab pane with the same hash name
+      var tabPane = document.querySelector(hash);
+      if (tabPane) {
+        // If matching tab exists
+        // get the tab-panes and nav-links
+        var tabPanes = document.querySelectorAll('.tab-pane');
+        // Get the nav link with href that matches the hash
+        var navLink = document.querySelector('a[href="'+ hash +'"]');
+        // Iterate over the tab-panes
+        for (var i = 0, len = tabPanes.length; i < len; i++) {
+          // Remove any existing .active class from the tab-pane
+          // mainly to remove the default tab content
+          tabPanes[i].classList.remove('active');
+        }
+        // Add .active class to the matching nav-link and tab-pane
+        navLink.classList.add('active');
+        tabPane.classList.add('active');
+      } else {
+        // If matching tab doesnt exist
+        // remove the hash from the URL
+        window.history.replaceState("", document.title, window.location.pathname);
+      }
+    }());
+  }
+  // Check if there are tabs in the dom and there are no hash
+  if (tabs) {
+    (function() {
+      // Check and get all the nav-links in the tab
+      var navLinks = document.querySelectorAll('.nav-link');
+      if (navLinks) {
+        // Iterate over all the nav-links
+        for (var i = 0, len = navLinks.length; i < len; i++) {
+          // Attach a click event listener to the nav-link
+          navLinks[i].addEventListener('click', function () {
+            // Get the hash from the nav-link href
+            var hash = this.getAttribute('href');
+            // Push the URL with hash to the history
+            // make hash appear in address bar
+            window.history.pushState("", document.title, window.location.pathname+hash);
+          });
+        }
+      }
+    }());
+  }
+}());

--- a/js/deeplink.js
+++ b/js/deeplink.js
@@ -1,53 +1,15 @@
-/* global window, document */
-(function () {
-  var hash = window.location.hash;
-  var tabs = document.querySelector('.tabs');
-  // Check if hash exists in url and a tabs element exists in the DOM
-  if (hash && tabs) {
-    // Wrap it in a self invoking anonymous function to scope the variables
-    (function() {
-      // Check if there is a tab pane with the same hash name
-      var tabPane = document.querySelector(hash);
-      if (tabPane) {
-        // If matching tab exists
-        // get the tab-panes and nav-links
-        var tabPanes = document.querySelectorAll('.tab-pane');
-        // Get the nav link with href that matches the hash
-        var navLink = document.querySelector('a[href="'+ hash +'"]');
-        // Iterate over the tab-panes
-        for (var i = 0, len = tabPanes.length; i < len; i++) {
-          // Remove any existing .active class from the tab-pane
-          // mainly to remove the default tab content
-          tabPanes[i].classList.remove('active');
-        }
-        // Add .active class to the matching nav-link and tab-pane
-        navLink.classList.add('active');
-        tabPane.classList.add('active');
-      } else {
-        // If matching tab doesnt exist
-        // remove the hash from the URL
-        window.history.replaceState("", document.title, window.location.pathname);
-      }
-    }());
+if (location.hash) {
+  var $hashTab = $(location.hash);
+  
+  if ($hashTab.hasClass('nav-link')) {
+    $hashTab.tab('show');
   }
-  // Check if there are tabs in the dom and there are no hash
-  if (tabs) {
-    (function() {
-      // Check and get all the nav-links in the tab
-      var navLinks = document.querySelectorAll('.nav-link');
-      if (navLinks) {
-        // Iterate over all the nav-links
-        for (var i = 0, len = navLinks.length; i < len; i++) {
-          // Attach a click event listener to the nav-link
-          navLinks[i].addEventListener('click', function () {
-            // Get the hash from the nav-link href
-            var hash = this.getAttribute('href');
-            // Push the URL with hash to the history
-            // make hash appear in address bar
-            window.history.pushState("", document.title, window.location.pathname+hash);
-          });
-        }
-      }
-    }());
-  }
-}());
+}
+
+$('.tabs .nav-link').on('show.bs.tab', function(e) {
+  history.replaceState(
+    history.state,
+    document.title,
+    location.pathname + '#' + e.currentTarget.id
+  );
+});


### PR DESCRIPTION
A response to issue #201 
The scripts detects the presence of a hash in the URL and a '.tabs' element on the DOM.
It activates the tabs with the same ID as the hash.
It removes the hash from the URL if there are no matching tabs.
It adds the hash of a tab on the URL bar when a tab is clicked.