### PR TITLE
Remove TODO from output html and replace it with a reference style blank link

### DIFF
--- a/en/org/release-process.md
+++ b/en/org/release-process.md
@@ -13,7 +13,7 @@ layout: guide
 5. Bump `latest_version` in [_config.yml on the website](https://github.com/yarnpkg/website/blob/master/_config.yml#L9). This updates the download URLs (`/latest.tar.gz` etc) to point to the new release. This will eventually be automated ([#187](https://github.com/yarnpkg/website/issues/187))
 6. Debian and CentOS repo should be automatically updated with the latest release within 5 minutes (keep an eye on [the commits](https://github.com/yarnpkg/releases/commits/gh-pages))
 
-TODO: Instructions for updating Chocolatey should go here - Currrently Daniel does that manually
+[TODO]: <> (Instructions for updating Chocolatey should go here - Currrently Daniel does that manually)
 
 ## To patch existing version of Yarn <a class="toc" id="toc-to-patch-existing-version-of-yarn" href="#toc-to-patch-existing-version-of-yarn"></a>
 

--- a/en/org/release-process.md
+++ b/en/org/release-process.md
@@ -13,7 +13,7 @@ layout: guide
 5. Bump `latest_version` in [_config.yml on the website](https://github.com/yarnpkg/website/blob/master/_config.yml#L9). This updates the download URLs (`/latest.tar.gz` etc) to point to the new release. This will eventually be automated ([#187](https://github.com/yarnpkg/website/issues/187))
 6. Debian and CentOS repo should be automatically updated with the latest release within 5 minutes (keep an eye on [the commits](https://github.com/yarnpkg/releases/commits/gh-pages))
 
-[TODO]: <> (Instructions for updating Chocolatey should go here - Currrently Daniel does that manually)
+<!-- [TODO: Instructions for updating Chocolatey should go here - Currrently Daniel does that manually] -->
 
 ## To patch existing version of Yarn <a class="toc" id="toc-to-patch-existing-version-of-yarn" href="#toc-to-patch-existing-version-of-yarn"></a>
 


### PR DESCRIPTION
Currently there's a TODO task showing on the page :
TODO: Instructions for updating Chocolatey should go here - Currrently Daniel does that manually

I'm assuming this is not meant to be shown on the site, only in the source code. 
I changed the TODO into a reference style link. It's a hack but I believe it's the only way in Markdown to keep comments out of the HTML output as discussed [here](http://stackoverflow.com/questions/4823468/comments-in-markdown)

`[TODO]: <> (Instructions for updating Chocolatey should go here - Currrently Daniel does that manually)
`
This also triggers the Internal Developer Info panel which only shows in development environments.