### PR TITLE
Fix #192 Document `npm rebuild equivalent` as `yarn install --force`

### DIFF
--- a/en/docs/migrating-from-npm.md
+++ b/en/docs/migrating-from-npm.md
@@ -53,6 +53,7 @@ your existing `npm-shrinkwrap.json` file and check in the newly created `yarn.lo
 | `npm install --save-exact [package]`        | `yarn add [package] --exact`                |
 | ***(N/A)***                                 | `yarn add [package] --tilde`                |
 | `npm install --global [package]`            | `yarn global add [package]`                 |
+| `npm rebuild`                               | `yarn install --force`                      |
 | `npm uninstall [package]`                   | ***(N/A)***                                 |
 | `npm uninstall --save [package]`            | `yarn remove [package]`                     |
 | `npm uninstall --save-dev [package]`        | `yarn remove [package]`                     |


### PR DESCRIPTION
This correlation was mentioned as being correct in #192 and https://github.com/yarnpkg/yarn/issues/1163.