### PR TITLE
break search bar into a smaller width on focus

### DIFF
--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -61,7 +61,7 @@ input#algolia-doc-search:focus {
   width: 240px;
 }
 
-@media screen and (max-width: 1085px) {
+@media screen and (max-width: 1200px) {
   input#algolia-doc-search:focus {
     width: 178px;
   }

--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -30,7 +30,7 @@
   margin-left: 15px;
 }
 
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 1150px) {
   .nav-item.algolia-search-wrapper {
     display: none;
   }


### PR DESCRIPTION
currently this happened on <1085px, but actually the nav gets slimmer from 1200px


suggested as a problem to fix by @thejameskyle in #208 