### PR TITLE
[Docs] Fixed tar command

### DIFF
--- a/en/docs/_installations/tarball.md
+++ b/en/docs/_installations/tarball.md
@@ -16,6 +16,6 @@ extracting it anywhere.
 ```sh
 cd /opt
 wget https://yarnpkg.com/latest.tar.gz
-tar zvxf yarn-*.tar.gz
+tar zvxf latest.tar.gz
 # Yarn is now in /opt/yarn-[version]/
 ```


### PR DESCRIPTION
The package is not named `yarn-*` except if you pass `-o` to `wget`, which is not the case.
