### PR TITLE
Remove multiple registries featurette

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -61,10 +61,6 @@ homepage_featurette_network_performance_title: Network Performance
 homepage_featurette_network_performance_description: |
   Yarn efficiently queues up requests and avoids request waterfalls in order
   to maximize network utilization.
-homepage_featurette_npm_and_bower_title: Multiple Registries
-homepage_featurette_npm_and_bower_description: |
-  Install any package from either npm or Bower and keep your package workflow
-  the same.
 homepage_featurette_network_resillience_title: Network Resilience
 homepage_featurette_network_resillience_description: |
   A single request failing won't cause an install to fail. Requests are retried

--- a/_layouts/pages/homepage.html
+++ b/_layouts/pages/homepage.html
@@ -107,10 +107,6 @@ shitty: Yes
       <h2>{{i18n.homepage_featurette_network_performance_title}}</h2>
       <p>{{i18n.homepage_featurette_network_performance_description}}</p>
     </div>
-    <div class="col-lg-4 col-md-6 featurette">
-      <h2>{{i18n.homepage_featurette_npm_and_bower_title}}</h2>
-      <p>{{i18n.homepage_featurette_npm_and_bower_description}}</p>
-    </div>
 
     <div class="col-lg-4 col-md-6 featurette">
       <h2>{{i18n.homepage_featurette_network_resillience_title}}</h2>


### PR DESCRIPTION
This solves #217 as well. This was the only reference to bower, and this bullet was also removed from the readme at [yarnpkg/yarn](https://github.com/yarnpkg/yarn).

@thejameskyle, not sure if you want to address any of the widths of the bottom 2 featurettes now, or leave them as is.
