### PR TITLE
Document new --no-git-tag-version option for yarn version

### DIFF
--- a/en/docs/cli/version.md
+++ b/en/docs/cli/version.md
@@ -52,3 +52,5 @@ info Current version: 1.0.2
 info New version: 1.0.3
 ✨  Done in 0.09s.
 ```
+
+If `yarn version --new-version <version>` is run in a Git repo, by default a new Git tag will be created. If you wish to surpress this behavior, you can use `yarn version --no-git-tag-version --new-version <version>`.


### PR DESCRIPTION
The new flag was commited to yarn 10 minutes ago: https://github.com/yarnpkg/yarn/commit/0c63149deddced5c7d4b1fe74fb0d0c496e6f888

Perhaps you wish to wait to merge this until the new version appears in a released version. 