### PR TITLE
Document `yarn version --new-version --no-git-tag-version`

### DIFF
--- a/en/docs/cli/version.md
+++ b/en/docs/cli/version.md
@@ -4,11 +4,14 @@ guide: docs_cli
 layout: guide
 ---
 
+{% include vars.html %}
+
 <p class="lead">Updates the package version.</p>
 
 ##### `yarn version` <a class="toc" id="toc-yarn-version" href="#toc-yarn-version"></a>
 
-Starts an interactive session to update the version. Once complete, `package.json` contains the new version information:
+Starts an interactive session to update the version. Once complete,
+`package.json` contains the new version information:
 
 Initial `package.json`:
 
@@ -23,6 +26,9 @@ Example run:
 
 ```sh
 $ yarn version
+```
+
+```
 info Current version: 1.0.1
 question New version: 1.0.2
 info New version: 1.0.2
@@ -48,30 +54,42 @@ Example:
 
 ```sh
 $ yarn version --new-version 1.0.3
+```
+
+```
 info Current version: 1.0.2
 info New version: 1.0.3
 ✨  Done in 0.09s.
 ```
 
-If `yarn version --new-version <version>` is run in a Git repo, by default a new annotated Git tag will be created. The default git message
-will be "v". Ex: "v1.0.3". To change the defaults for the git-related actions of creating a new versions, you can change the defaults of
-the following configuration default values with `yarn config set <key> value:
+If `yarn version --new-version <version>` is run in a Git repo, by default a
+new annotated Git tag will be created. The default git message will be "v". Ex:
+"v1.0.3". To change the defaults for the git-related actions of creating a new
+versions, you can change the defaults of the following configuration default
+values with `yarn config set <key> value:
 
-    // String to prefix git versions with
-    'version-tag-prefix': 'v'
+```js
+// String to prefix git versions with
+'version-tag-prefix': 'v'
 
-    // Whether to create git tags by default
-    'version-git-tag': true
+// Whether to create git tags by default
+'version-git-tag': true
 
-    // Whether to sign git tags by default
-    'version-git-sign': false
+// Whether to sign git tags by default
+'version-git-sign': false
 
-    // Default git message, where %s is the version string
-    'version-git-message': 'v%s'
-
+// Default git message, where %s is the version string
+'version-git-message': 'v%s'
+```
 
 ##### `yarn version --new-version --no-git-tag-version <version>` <a class="toc" id="toc-yarn-version-new-version-no-git" href="#toc-yarn-version-new-version-no-git"></a>
 
-Works as `yarn version --new-version <version>` above, but disables the creation of a new git tag for a single call. To disable git tag creation by default
-set `yarn config set version-git-tag false`
+Works the same as `yarn version --new-version <version>`, but does not create a
+new git tag.
 
+To disable this behavior by default you can use
+[`yarn config`]({{url_base}}/docs/cli/config):
+
+```sh
+yarn config set version-git-tag false
+```

--- a/en/docs/cli/version.md
+++ b/en/docs/cli/version.md
@@ -52,3 +52,26 @@ info Current version: 1.0.2
 info New version: 1.0.3
 ✨  Done in 0.09s.
 ```
+
+If `yarn version --new-version <version>` is run in a Git repo, by default a new annotated Git tag will be created. The default git message
+will be "v". Ex: "v1.0.3". To change the defaults for the git-related actions of creating a new versions, you can change the defaults of
+the following configuration default values with `yarn config set <key> value:
+
+    // String to prefix git versions with
+    'version-tag-prefix': 'v'
+
+    // Whether to create git tags by default
+    'version-git-tag': true
+
+    // Whether to sign git tags by default
+    'version-git-sign': false
+
+    // Default git message, where %s is the version string
+    'version-git-message': 'v%s'
+
+
+##### `yarn version --new-version --no-git-tag-version <version>` <a class="toc" id="toc-yarn-version-new-version-no-git" href="#toc-yarn-version-new-version-no-git"></a>
+
+Works as `yarn version --new-version <version>` above, but disables the creation of a new git tag for a single call. To disable git tag creation by default
+set `yarn config set version-git-tag false`
+


### PR DESCRIPTION
As well as other config values that affect `yarn version --new-version`.

Supercedes PR#222