### PR TITLE
fix broken link

### DIFF
--- a/en/docs/package-json.md
+++ b/en/docs/package-json.md
@@ -4,6 +4,8 @@ guide: docs_configuration
 layout: guide
 ---
 
+{% include vars.html %}
+
 ## Essentials <a class="toc" id="toc-essentials" href="#toc-essentials"></a>
 
 The two most important fields in your `package.json` are `name` and `version`,


### PR DESCRIPTION
`url_base` was wrong, thus causing `docs/cli/install#toc-yarn-install-flat` to 404.