### PR TITLE
Document that `install` is the default `yarn` command.

### DIFF
--- a/en/docs/cli/index.md
+++ b/en/docs/cli/index.md
@@ -15,3 +15,7 @@ While all of the available commands are provided here, in alphabetical order, so
 - [`yarn install`]({{url_base}}/docs/cli/install): installs all the dependencies defined in a `package.json` file.
 - [`yarn publish`]({{url_base}}/docs/cli/publish): publishes a package to a package manager.
 - [`yarn remove`]({{url_base}}/docs/cli/remove): removes an unused package from your current package.
+
+## Default Command <a class="toc" id="toc-default-command" href="#toc-default-command"></a>
+
+Running `yarn` with no command will run `yarn install`, passing through any provided flags.

--- a/en/docs/cli/install.md
+++ b/en/docs/cli/install.md
@@ -16,6 +16,8 @@ If you are used to using npm you might be expecting to use `--save` or
 more information, see
 [the `yarn add` documentation]({{url_base}}/docs/cli/add).
 
+Running `yarn` with no command will run `yarn install`, passing through any provided flags.
+
 ##### `yarn install` <a class="toc" id="toc-yarn-install" href="#toc-yarn-install"></a>
 
 Install all the dependencies listed within `package.json` in the local


### PR DESCRIPTION
Mentions of this feature were added in two places:

 1. The CLI overview for page where one might look to see what the default action is.
 2. The `install` page, where someone might be interested to find the
 shortcut.