### PR TITLE
docs for yarn run <args>

### DIFF
--- a/en/docs/cli/run.md
+++ b/en/docs/cli/run.md
@@ -33,6 +33,18 @@ yarn run test
 Running this command will execute the script named `"test"` in your
 `package.json`.
 
+`[script]` can also be any locally installed executable that is inside `node_modules/.bin/`.
+
+##### `yarn run [script] -- <args>` <a class="toc" id="toc-yarn-run-script-args" href="#toc-yarn-run-script-args"></a>
+
+You can use this syntax to pass additional args to your script.
+
+```sh
+yarn run test -- -o -w
+```
+
+Running this command will execute `jest -o --watch`.
+
 ##### `yarn run` <a class="toc" id="toc-yarn-run" href="#toc-yarn-run"></a>
 
 If you do not specify a script to the `yarn run` command, the `run` command

--- a/en/docs/cli/run.md
+++ b/en/docs/cli/run.md
@@ -21,7 +21,7 @@ You may define [`scripts`]({{url_base}}/docs/package-json#toc-scripts) in your
 }
 ```
 
-##### `yarn run [script]` <a class="toc" id="toc-yarn-run-script" href="#toc-yarn-run-script"></a>
+##### `yarn run [script] [-- <args>]` <a class="toc" id="toc-yarn-run-script" href="#toc-yarn-run-script"></a>
 
 If you have defined a `scripts` object in your package, this command will run
 the specified `[script]`. For example:
@@ -33,17 +33,15 @@ yarn run test
 Running this command will execute the script named `"test"` in your
 `package.json`.
 
-`[script]` can also be any locally installed executable that is inside `node_modules/.bin/`.
-
-##### `yarn run [script] -- <args>` <a class="toc" id="toc-yarn-run-script-args" href="#toc-yarn-run-script-args"></a>
-
-You can use this syntax to pass additional args to your script.
+You can pass additional arguments to your script by using `--`.
 
 ```sh
-yarn run test -- -o -w
+yarn run test -- -o --watch
 ```
 
 Running this command will execute `jest -o --watch`.
+
+`[script]` can also be any locally installed executable that is inside `node_modules/.bin/`.
 
 ##### `yarn run` <a class="toc" id="toc-yarn-run" href="#toc-yarn-run"></a>
 


### PR DESCRIPTION
This commit contains two additions:

1. additional arguments for `yarn run`
2. `[script]` can also be any executable inside `node_modules/.bin/`