### PR TITLE
Load GPG key from URL rather than keyserver

### DIFF
--- a/en/docs/_ci/circle.md
+++ b/en/docs/_ci/circle.md
@@ -4,7 +4,7 @@ On [CircleCI](https://circleci.com/), you can install Yarn as part of your build
 dependencies:
   pre:
     # Install Yarn
-    - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+    - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
     - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     - sudo apt-get update -qq
     - sudo apt-get install -y -qq yarn

--- a/en/docs/_ci/travis.md
+++ b/en/docs/_ci/travis.md
@@ -5,7 +5,7 @@ before_install:
   # Repo for newer Node.js versions
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   # Repo for Yarn
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq yarn

--- a/en/docs/_installations/linux.md
+++ b/en/docs/_installations/linux.md
@@ -4,7 +4,7 @@ On Debian or Ubuntu Linux, you can install Yarn via our Debian package
 repository. You will first need to configure the repository:
 
 ```sh
-sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 ```
 


### PR DESCRIPTION
We've seen `pgp.mit.edu` fail a few times, and other keyservers have issues too (eg. see https://github.com/docker/docker/issues/20022). I've changed our instructions to load the GPG public key from a URL we host, rather than a keyserver. This will hopefully make installations less flaky (they won't fail when the keyserver has issues)

HTTPS doesn't work in all environments, so I'm just using regular HTTP:
> gpgkeys: protocol 'https' not supported
> gpg: no handler for keyserver scheme 'https'
> gpg: WARNING: unable to fetch URI https://dl.yarnpkg.com/debian/pubkey.gpg: keyserver error
