### PR TITLE
Document new 'yarn ls <pkgname> variation added by 65a2794c1d9c316cc8c53c6fd08872dd94af584c

### DIFF
--- a/en/docs/cli/ls.md
+++ b/en/docs/cli/ls.md
@@ -19,3 +19,13 @@ yarn ls vx.x.x
 │  └─ package-3@^2.1.0
 └─ package-3@2.7.0
 ```
+##### `yarn ls <pkgname>` <a class="toc" id="toc-yarn-ls-name" href="#toc-yarn-ls-name"></a>
+
+```sh
+yarn ls gulp
+```
+
+```
+yarn ls vx.x.x
+└─ gulp@3.9.1
+`


### PR DESCRIPTION
Considering waiting to merge this a bit, though: the new command seems
to have a bug: https://github.com/yarnpkg/yarn/issues/1599#issuecomment-258149681