### PR TITLE
Remove reference to npm

### DIFF
--- a/en/docs/creating-a-package.md
+++ b/en/docs/creating-a-package.md
@@ -46,7 +46,7 @@ You can type answers for each of these or you can just hit enter/return to use
 the default or leave it blank.
 
 > **Tip:** If you want to use the defaults for everything you can also run
-> `npm init --yes` and it will skip all the questions.
+> `yarn init --yes` and it will skip all the questions.
 
 ### `package.json` <a class="toc" id="toc-package-json" href="#toc-package-json"></a>
 


### PR DESCRIPTION
The yarn website contains a mention of `npm init` which should probably be changed to `yarn init`, this PR fixes that.