### PR TITLE
Move nightly builds page to site

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -9,8 +9,6 @@
     path: /docs/install
   - id: docs_usage
     path: /docs/usage
-  - id: docs_nightly
-    path: /docs/nightly
 
 - id: docs_yarn_workflow
   title: docs_yarn_workflow_title

--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -9,6 +9,8 @@
     path: /docs/install
   - id: docs_usage
     path: /docs/usage
+  - id: docs_nightly
+    path: /docs/nightly
 
 - id: docs_yarn_workflow
   title: docs_yarn_workflow_title

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -225,7 +225,7 @@ install_problems_description: >
 install_problems_search: Search for an existing issue
 install_problems_new_issue: Open a new issue
 
-install_nightly_title: Nightly Builds
+docs_nightly: Nightly Builds
 install_nightly_intro: >
   Nightly builds are the latest and greatest versions of Yarn, built using the
   very latest Yarn source code. Nightly builds are useful to try new features or
@@ -234,6 +234,23 @@ install_nightly_intro: >
   have bugs.
 install_nightly_learn_more: See how to install nightly builds
 
+nightly_latest_version: Latest Version
+nightly_older_versions: Older Versions
+nightly_select_build_type: Select a build type above to see older builds
+install_table_name: Name
+# "Type" refers to type of artifact - tarball, Windows installer, Debian package, etc.
+install_table_type: Type
+install_table_size: Size
+install_table_date: Date
+loading: Loading...
+
+install_file:
+  deb: Debian package
+  js: Standalone JS
+  js-legacy: Standalone JS (Node < 4.0)
+  msi: Windows installer
+  rpm: RPM
+  tar: Tarball
 
 docs_install_ci: Continuous Integration
 ci_intro: >

--- a/_data/nightly_types.yml
+++ b/_data/nightly_types.yml
@@ -1,0 +1,7 @@
+# Types of files available as part of the nightly builds
+- tar
+- deb
+- msi
+- rpm
+- js
+#- js-legacy

--- a/en/docs/_installations/nightly.md
+++ b/en/docs/_installations/nightly.md
@@ -1,3 +1,5 @@
+{{i18n.install_nightly_intro}}
+
 The easiest way of installing a nightly build is via our shell script:
 ```sh
 wget https://yarnpkg.com/install.sh
@@ -13,5 +15,3 @@ sudo apt-get update && sudo apt-get install yarn
 ```
 
 On Windows, the [Windows installer](https://nightly.yarnpkg.com/latest.msi) can be used.
-
-See [the nightly build site](https://nightly.yarnpkg.com/) for more information.

--- a/en/docs/install.html
+++ b/en/docs/install.html
@@ -15,7 +15,6 @@ scripts:
 {% capture windows      %}{% include_relative _installations/windows.md      %}{% endcapture %}
 {% capture linux        %}{% include_relative _installations/linux.md        %}{% endcapture %}
 {% capture alternatives %}{% include_relative _installations/alternatives.md %}{% endcapture %}
-{% capture nightly      %}{% include_relative _installations/nightly.md      %}{% endcapture %}
 
 <div class="tabs">
   <div class="nav nav-tabs bg-faded text-xs-center">
@@ -50,16 +49,13 @@ scripts:
 <div class="language-sh highlighter-rouge"><pre class="rougeHighlight"><code>yarn --version</code></pre>
 </div>
 
-<h3>{{i18n.install_nightly_title}}</h3>
+<h3>{{i18n.docs_nightly}}</h3>
 <p>{{i18n.install_nightly_intro}}</p>
 <p>
-  <a id="nightlyHeading" class="collapsed" role="button" data-toggle="collapse" href="#nightly" aria-expanded="false" aria-controls="nightly">
+  <a href="{{url_base}}/docs/nightly">
     {{i18n.install_nightly_learn_more}}
   </a>
 </p>
-<div id="nightly" class="panel-collapse collapse" role="tabpanel" aria-labelledby="nightlyHeading">
-  {{nightly | markdownify}}
-</div>
 
 {% capture issueBody %}
 **Which operating system are you using:**

--- a/en/docs/nightly.html
+++ b/en/docs/nightly.html
@@ -1,0 +1,77 @@
+---
+id: docs_nightly
+guide: docs_getting_started
+layout: guide
+scripts:
+  - "/js/nightly.js"
+---
+
+{% include vars.html %}
+
+{% capture nightly %}{% include_relative _installations/nightly.md %}{% endcapture %}
+{{nightly | markdownify}}
+
+<h2>{{i18n.nightly_latest_version}}</h2>
+<table>
+  <thead>
+    <tr>
+      <th width="45%">{{i18n.install_table_name}}</th>
+      <th width="25%">{{i18n.install_table_type}}</th>
+      <th width="15%">{{i18n.install_table_size}}</th>
+      <th width="15%">{{i18n.install_table_date}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for type in site.data.nightly_types %}
+      <tr id="row_{{type}}">
+        <td>
+          <a class="link" href="https://nightly.yarnpkg.com/latest.{{type}}">
+            <span class="filename">{{i18n.loading}}</span>
+          </a>
+        </td>
+        <td>{{i18n.install_file[type]}}</td>
+        <td class="size"></td>
+        <td class="date"></td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<h2>{{i18n.nightly_older_versions}}</h2>
+<div class="tabs">
+  <div id="older-versions" class="nav nav-tabs bg-faded text-xs-center">
+    <ul class="nav navbar-nav nav-inline">
+      {% for type in site.data.nightly_types %}
+        <a id="{{type}}-tab" class="nav-item nav-link" data-type="{{type}}" data-toggle="tab" href="#{{type}}">
+          {{i18n.install_file[type]}}
+        </a>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <div class="tab-content">
+    <div id="select-platform" class="tab-pane bg-faded active">
+      <p class="text-xs-center my-4 text-muted">
+        {{i18n.nightly_select_build_type}}
+      </p>
+    </div>
+    {% for type in site.data.nightly_types %}
+      <div class="tab-pane" id="{{type}}">
+        <table>
+          <thead>
+            <tr>
+              <th width="60%">{{i18n.install_table_name}}</th>
+              <th width="20%">{{i18n.install_table_size}}</th>
+              <th width="20%">{{i18n.install_table_date}}</th>
+            </tr>
+          </thead>
+          <tbody id="{{type}}-body">
+            <tr>
+              <td colspan="3">{{i18n.loading}}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/js/nightly.js
+++ b/js/nightly.js
@@ -1,0 +1,59 @@
+(function() {
+  var MS_PER_SEC = 1000;
+  var SEC_PER_MINUTE = 60;
+  var SEC_PER_HOUR = 3600;
+  var SEC_PER_DAY = 86400;
+  function formatTimeSince(timestamp) {
+    var diff = Date.now() / MS_PER_SEC - timestamp;
+    if (diff < SEC_PER_HOUR) {
+      return Math.floor(diff / SEC_PER_MINUTE) + ' minutes ago';
+    } else if (diff < SEC_PER_DAY) {
+      return Math.floor(diff / SEC_PER_HOUR) + ' hours ago';
+    } else {
+      return Math.floor(diff / SEC_PER_DAY) + ' days ago';
+    }
+  }
+
+  function load() {
+    var xhr = new XMLHttpRequest();
+    xhr.open('get', 'https://nightly.yarnpkg.com/latest.json', true);
+    xhr.onload = function() {
+      var allFiles = JSON.parse(xhr.responseText);
+      Object.keys(allFiles).forEach(function(type) {
+        var file = allFiles[type];
+        var row = document.getElementById('row_' + type);
+        if (!row) {
+          return;
+        }
+        row.querySelector('.date').textContent = formatTimeSince(file.date);
+        row.querySelector('.filename').textContent = file.filename;
+        row.querySelector('.link').href = file.url;
+        row.querySelector('.size').textContent = file.size;
+      });
+    };
+    xhr.send();
+  }
+
+  $('#older-versions .nav-item').on('shown.bs.tab', function(e) {
+    var selectedType = e.target.getAttribute('data-type');
+    var xhr = new XMLHttpRequest();
+    xhr.open('get', 'https://nightly.yarnpkg.com/' + selectedType + '-builds', true);
+    xhr.onload = function() {
+      var allBuilds = JSON.parse(xhr.responseText);
+      var tbody = $('<tbody>');
+      allBuilds.forEach(function(build) {
+        tbody.append(
+          $('<tr>').append(
+            $('<td>').append($('<a>').attr('href', build.url).text(build.filename)),
+            $('<td>').text(build.size),
+            $('<td>').text(formatTimeSince(build.date))
+          )
+        );
+      });
+      tbody.replaceAll('#' + selectedType + '-body');
+    };
+    xhr.send();
+  });
+
+  load();
+}());

--- a/js/nightly.js
+++ b/js/nightly.js
@@ -5,13 +5,23 @@
   var SEC_PER_DAY = 86400;
   function formatTimeSince(timestamp) {
     var diff = Date.now() / MS_PER_SEC - timestamp;
+    var singlarString, pluralString, divisor;
     if (diff < SEC_PER_HOUR) {
-      return Math.floor(diff / SEC_PER_MINUTE) + ' minutes ago';
+      // TODO: Localize these.
+      singularString = '1 minute ago';
+      pluralString = '{count} minutes ago';
+      divisor = SEC_PER_MINUTE;
     } else if (diff < SEC_PER_DAY) {
-      return Math.floor(diff / SEC_PER_HOUR) + ' hours ago';
+      singularString = '1 hour ago';
+      pluralString = '{count} hours ago';
+      divisor = SEC_PER_HOUR;
     } else {
-      return Math.floor(diff / SEC_PER_DAY) + ' days ago';
+      singularString = '1 day ago';
+      pluralString = '{count} days ago';
+      divisor = SEC_PER_DAY;
     }
+    diff = Math.floor(diff / divisor);
+    return (diff === 1 ? singularString : pluralString).replace('{count}', diff);
   }
 
   function load() {


### PR DESCRIPTION
Moves the page at https://nightly.yarnpkg.com/ onto the main site. The list of available builds is loaded via an AJAX request from the nightly build server.

Once this lands, I'll make https://nightly.yarnpkg.com/ redirect to it and kill that old page. It was mainly for prototyping some ideas 😄 

cc @thejameskyle 

Closes #259