### PR TITLE
Revert version to 0.16.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ baseurl: ""
 url: "https://yarnpkg.com"
 twitter_username: yarnpkg
 github_username:  yarnpkg
-latest_version: 0.17.0
+latest_version: 0.16.1
 gacode: "UA-85522875-1"
 
 exclude:


### PR DESCRIPTION
There's been quite a few breaking bugs reported with 0.17.0, so I feel like we either need to roll back to 0.16.1 or roll forward and release a patched version (eg. 0.17.1). I'll leave this up to you to decide what to do - Feel free to merge this PR if you want to roll back, or just close this PR if you roll forward.

Currently the installation script is breaking and it uses this version number to determine the version to install.

@yarnpkg/core 