### PR TITLE
Add information about installing specific version of Yarn on Travis and Circle

### DIFF
--- a/en/docs/_ci/circle.md
+++ b/en/docs/_ci/circle.md
@@ -12,5 +12,7 @@ dependencies:
     - "~/.yarn-cache"
 ```
 
+{% include_relative _ci/deb-specific-version.md %}
+
 > Let CircleCI know if you want Yarn to be
 > [installed by default](https://discuss.circleci.com/t/preinstall-yarn/7353).

--- a/en/docs/_ci/deb-specific-version.md
+++ b/en/docs/_ci/deb-specific-version.md
@@ -1,0 +1,4 @@
+It is recommended that you lock in a specific version of Yarn, so that all your builds use the same version of Yarn, and you can test new Yarn releases before switching over. You can do this by adding the version number to the `apt-get install` call:
+```
+sudo apt-get install -y -qq yarn={{site.latest_version}}-1
+```

--- a/en/docs/_ci/travis.md
+++ b/en/docs/_ci/travis.md
@@ -14,5 +14,7 @@ cache:
   - $HOME/.yarn-cache
 ```
 
+{% include_relative _ci/deb-specific-version.md %}
+
 > Let Travis CI know if you want Yarn to be
 > [installed by default](https://github.com/travis-ci/travis-ci/issues/6720).


### PR DESCRIPTION
Now that our Debian repo can contain multiple version of Yarn (implemented in https://github.com/yarnpkg/yarn/issues/1839), we should advocate locking the version of Yarn used in CI environments. The main reason is so that people's builds don't suddenly break because they're always installing the latest version of Yarn (which could have breaking changes for their environment) 😛 