### PR TITLE
Remove redundant sudo from Debian install instructions

### DIFF
--- a/en/docs/_installations/linux.md
+++ b/en/docs/_installations/linux.md
@@ -4,7 +4,7 @@ On Debian or Ubuntu Linux, you can install Yarn via our Debian package
 repository. You will first need to configure the repository:
 
 ```sh
-sudo curl https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 ```
 


### PR DESCRIPTION
There's no need to run curl as root if it's writing the contents to standard output. Verified that the new command works just as well on my Debian system.