### PR TITLE
Incldue --ignore-optional doc

### DIFF
--- a/en/docs/cli/add.md
+++ b/en/docs/cli/add.md
@@ -89,7 +89,11 @@ Using `--peer` or `-P` will install one or more packages in your
 ##### `yarn add <package...> [--optional,-O]` <a class="toc" id="toc-yarn-add-optional-o" href="#toc-yarn-add-optional-o"></a>
 
 Using `--optional` or `-O` will install one or more packages in your
-[`optionalDependencies`]({{url_base}}/docs/dependency-types#toc-optional-dependencies).
+[`optionalDependencies`]({{url_base}}/docs/dependency-types#toc-optionaldependencies).
+
+##### `yarn add <package...> [--ignore-optional]` <a class="toc" id="toc-yarn-add-ignore-optional-o" href="#toc-yarn-add-optional-o"></a>
+Using `--ignore-optional` will skip dependencies labeled as optional in your package.json file
+[`optionalDependencies`]({{url_base}}/docs/dependency-types#toc-optionaldependencies).
 
 ##### `yarn add <package...> [--exact/-E]` <a class="toc" id="toc-yarn-add-exact-e" href="#toc-yarn-add-exact-e"></a>
 


### PR DESCRIPTION
Resolves #265.

Two changes:

1. Fix broken link to optionalDependencies
2. Include documentation for the --ignore-optional CLI command

Looks like this (locally):

<img width="1020" alt="screen shot 2016-11-17 at 9 05 30 am" src="https://cloud.githubusercontent.com/assets/5561166/20392270/0be5cb22-aca5-11e6-8e74-3d89a05a26f6.png">
