### PR TITLE
Clarify install documentation

### DIFF
--- a/en/docs/cli/install.md
+++ b/en/docs/cli/install.md
@@ -20,8 +20,8 @@ Running `yarn` with no command will run `yarn install`, passing through any prov
 
 ##### `yarn install` <a class="toc" id="toc-yarn-install" href="#toc-yarn-install"></a>
 
-Install all the dependencies listed within `package.json` in the local
-`node_modules` folder.
+Install all the dependencies listed within `yarn.lock` in the local
+`node_modules` folder. Note: `package.json` will be used if `yarn.lock` is not present.
 
 ##### `yarn install --flat` <a class="toc" id="toc-yarn-install-flat" href="#toc-yarn-install-flat"></a>
 


### PR DESCRIPTION
It's unexpected that the `yarn install` command would not respect the versions listed in `package.json`. That's less than ideal, in my personal opinion, as I'd prefer to just run `yarn` every time I update my `package.json` to get the new versions installed. However, if this is in fact the intended behavior, we should at least update the documentation to make it clear that this is the behavior, since the current documentation explicitly describes the behavior I expected, which is not what was implemented.