### PR TITLE
Refer to `yarn global bin` in path setup

### DIFF
--- a/en/docs/_installations/unix_path_setup.md
+++ b/en/docs/_installations/unix_path_setup.md
@@ -1,3 +1,3 @@
 You will need to set up the `PATH` environment variable in your terminal to have access to Yarn's binaries globally.
 
-Add `export PATH="$PATH:$HOME/.yarn/bin"` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)
+Add ``export PATH="$PATH:`yarn global bin`"`` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)


### PR DESCRIPTION
When installing with Homebrew or other tools, yarn doesn't always use `~/.yarn/bin`. Instead direct users to use `yarn global bin` to refer to the correct path.