### PR TITLE
Add documentation for --mutex

### DIFF
--- a/en/docs/cli/index.md
+++ b/en/docs/cli/index.md
@@ -20,7 +20,7 @@ While all of the available commands are provided here, in alphabetical order, so
 
 Running `yarn` with no command will run `yarn install`, passing through any provided flags.
 
-## Concurrency and `--mutex` <a class="toc" id="toc-default-command" href="#toc-concurrency-and---mutex"></a>
+## Concurrency and `--mutex` <a class="toc" id="toc-concurrency-and-mutex" href="#toc-concurrency-and-mutex"></a>
 When running multiple instances of yarn as the same user on the same server,
 you can ensure only one instance runs at any given time (and avoid conflicts)
 by passing the global flag `--mutex` followed by `file` or `network`. 

--- a/en/docs/cli/index.md
+++ b/en/docs/cli/index.md
@@ -22,4 +22,6 @@ Running `yarn` with no command will run `yarn install`, passing through any prov
 
 ## Concurrency and --mutex
 
-When running multiple instances of yarn as the same user on the same server, you can ensure only one instance runs at any given time (and avoid conflicts) by passing the global flag `--mutex (file|network)`. This will write/read a mutex file `.yarn-single-instance` in the current working directory or open network port 31997. You can specify an alternate or global filename, or an alternate network port by specifying `--mutex file:/tmp/.yarn-mutex` or `--mutex network:31999`.
+When running multiple instances of yarn as the same user on the same server, you can ensure only one instance runs at any given time (and avoid conflicts) by passing the global flag `--mutex` followed by `file` or `network`. 
+
+The `file` option will write/read a mutex file `.yarn-single-instance` in the current working directory by default, or you can specify an alternate or global filename by specifying it in the form `--mutex file:/tmp/.yarn-mutex`. The `network` option will default to network port 31997, or you can specify an alternate port by passing `--mutex network:30330`.

--- a/en/docs/cli/index.md
+++ b/en/docs/cli/index.md
@@ -21,7 +21,23 @@ While all of the available commands are provided here, in alphabetical order, so
 Running `yarn` with no command will run `yarn install`, passing through any provided flags.
 
 ## Concurrency and --mutex
+When running multiple instances of yarn as the same user on the same server,
+you can ensure only one instance runs at any given time (and avoid conflicts)
+by passing the global flag `--mutex` followed by `file` or `network`. 
 
-When running multiple instances of yarn as the same user on the same server, you can ensure only one instance runs at any given time (and avoid conflicts) by passing the global flag `--mutex` followed by `file` or `network`. 
+When using `file` Yarn will write/read a mutex file `.yarn-single-instance` in
+the current working directory by default. You can also specify an alternate or
+global filename.
 
-The `file` option will write/read a mutex file `.yarn-single-instance` in the current working directory by default, or you can specify an alternate or global filename by specifying it in the form `--mutex file:/tmp/.yarn-mutex`. The `network` option will default to network port `31997`, or you can specify an alternate port by passing `--mutex network:30330`.
+```sh
+--mutex file
+--mutex file:/tmp/.yarn-mutex
+```
+
+When using `network` Yarn will create a server at port `31997` by default. You
+can also specify an alternate port.
+
+```sh
+--mutex network
+--mutex network:30330
+```

--- a/en/docs/cli/index.md
+++ b/en/docs/cli/index.md
@@ -19,3 +19,7 @@ While all of the available commands are provided here, in alphabetical order, so
 ## Default Command <a class="toc" id="toc-default-command" href="#toc-default-command"></a>
 
 Running `yarn` with no command will run `yarn install`, passing through any provided flags.
+
+## Concurrency and --mutex
+
+When running multiple instances of yarn as the same user on the same server, you can ensure only one instance runs at any given time (and avoid conflicts) by passing the global flag `--mutex (file|network)`. This will write/read a mutex file `.yarn-single-instance` in the current working directory or open network port 31997. You can specify an alternate or global filename, or an alternate network port by specifying `--mutex file:/tmp/.yarn-mutex` or `--mutex network:31999`.

--- a/en/docs/cli/index.md
+++ b/en/docs/cli/index.md
@@ -24,4 +24,4 @@ Running `yarn` with no command will run `yarn install`, passing through any prov
 
 When running multiple instances of yarn as the same user on the same server, you can ensure only one instance runs at any given time (and avoid conflicts) by passing the global flag `--mutex` followed by `file` or `network`. 
 
-The `file` option will write/read a mutex file `.yarn-single-instance` in the current working directory by default, or you can specify an alternate or global filename by specifying it in the form `--mutex file:/tmp/.yarn-mutex`. The `network` option will default to network port 31997, or you can specify an alternate port by passing `--mutex network:30330`.
+The `file` option will write/read a mutex file `.yarn-single-instance` in the current working directory by default, or you can specify an alternate or global filename by specifying it in the form `--mutex file:/tmp/.yarn-mutex`. The `network` option will default to network port `31997`, or you can specify an alternate port by passing `--mutex network:30330`.

--- a/en/docs/cli/index.md
+++ b/en/docs/cli/index.md
@@ -20,7 +20,7 @@ While all of the available commands are provided here, in alphabetical order, so
 
 Running `yarn` with no command will run `yarn install`, passing through any provided flags.
 
-## Concurrency and --mutex
+## Concurrency and `--mutex` <a class="toc" id="toc-default-command" href="#toc-concurrency-and---mutex"></a>
 When running multiple instances of yarn as the same user on the same server,
 you can ensure only one instance runs at any given time (and avoid conflicts)
 by passing the global flag `--mutex` followed by `file` or `network`. 


### PR DESCRIPTION
Adds a note in `cli/index.md` describing usage of the `--mutex` flag in both file and network modes.

Fixes #261 