### PR TITLE
Update Travis CI integration

### DIFF
--- a/en/docs/_ci/travis.md
+++ b/en/docs/_ci/travis.md
@@ -1,7 +1,16 @@
-On [Travis CI](https://travis-ci.org/), you can install Yarn as part of your build by adding this to your `.travis.yml` file:
+[Travis CI](https://travis-ci.org/) detects the use of Yarn by the presence of `yarn.lock` in the repository root.
+If it is available, Travis CI will install `yarn` if necessary, and execute `yarn` as the default install command.
+
+If your install phase requires more, it is necessary to install Yarn yourself until it is pre-installed on build images.
+
+There are a couple of ways to install Yarn; one with `sudo`, the other without.
+If you are using the [container-based environment](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments)
+use the latter.
+
+## `sudo`-enabled builds
 
 ```yml
-before_install:
+before_install: # if "install" is overridden
   # Repo for Yarn
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
@@ -14,5 +23,13 @@ cache:
 
 {% include_relative _ci/deb-specific-version.md %}
 
-> Let Travis CI know if you want Yarn to be
-> [installed by default](https://github.com/travis-ci/travis-ci/issues/6720).
+## container-based builds
+
+Container-based builds do not have the `sudo` privilege, so they must rely on other means to install.
+For example:
+
+```yaml
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+```

--- a/en/docs/_ci/travis.md
+++ b/en/docs/_ci/travis.md
@@ -10,6 +10,7 @@ use the latter.
 ## `sudo`-enabled builds
 
 ```yml
+sudo: required
 before_install: # if "install" is overridden
   # Repo for Yarn
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
@@ -29,6 +30,7 @@ Container-based builds do not have the `sudo` privilege, so they must rely on ot
 For example:
 
 ```yaml
+sudo: false
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH


### PR DESCRIPTION
Travis CI has announced Yarn support on 2016-11-21. https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn

This update describes the current support status of Travis CI on that date.