### PR TITLE
Removing inaccurate line from the migration docs

### DIFF
--- a/en/docs/migrating-from-npm.md
+++ b/en/docs/migrating-from-npm.md
@@ -59,4 +59,3 @@ your existing `npm-shrinkwrap.json` file and check in the newly created `yarn.lo
 | `npm uninstall --save-dev [package]`        | `yarn remove [package]`                     |
 | `npm uninstall --save-optional [package]`   | `yarn remove [package]`                     |
 | `npm cache clean`                           | `yarn cache clean`                          |
-| `rm -rf node_modules && npm install`        | `yarn upgrade`                              |


### PR DESCRIPTION
`yarn upgrade` is not the same as `rm -rf node_modules/ && npm install`. The npm install command doesn't upgrade dependancies to their latest