### PR TITLE
Fix CircleCI instruction

### DIFF
--- a/en/docs/_ci/circle.md
+++ b/en/docs/_ci/circle.md
@@ -9,7 +9,9 @@ dependencies:
     - sudo apt-get update -qq
     - sudo apt-get install -y -qq yarn
   cache_directories:
-    - "~/.yarn-cache"
+    - ~/.yarn-cache
+  override:
+    - yarn install
 ```
 
 {% include_relative _ci/deb-specific-version.md %}


### PR DESCRIPTION
Without `override`, CircleCI will run `npm install` instead of `yarn install`