### PR TITLE
init: document config variables that can influence `yarn init`.

### DIFF
--- a/en/docs/cli/init.md
+++ b/en/docs/cli/init.md
@@ -4,6 +4,8 @@ guide: docs_cli
 layout: guide
 ---
 
+{% include vars.html %}
+
 <p class="lead">Interactively creates or updates a package.json file.</p>
 
 ##### `yarn init` <a class="toc" id="toc-yarn-init" href="#toc-yarn-init"></a>
@@ -83,15 +85,16 @@ success Saved package.json
 ✨  Done in 121.53s.
 ```
 
-##### Setting defaults for  `yarn init` <a class="toc" id="toc-yarn-init-defaults" href="#toc-yarn-init-defaults"></a>
+##### Setting defaults for `yarn init` <a class="toc" id="toc-setting-defaults-for-yarn-init" href="#toc-setting-defaults-for-yarn-init"></a>
 
-The following [config](./config) variables can be used to customize the defaults for `yarn init`:
+The following [config]({{url_base}}/docs/cli/config) variables can be used to
+customize the defaults for `yarn init`:
 
- * init-author-name
- * init-author-email
- * init-author-url
- * init-version
- * init-license
+ - `init-author-name`
+ - `init-author-email`
+ - `init-author-url`
+ - `init-version`
+ - `init-license`
 
 ##### `yarn init --yes/-y` <a class="toc" id="toc-yarn-init-yes-y" href="#toc-yarn-init-yes-y"></a>
 

--- a/en/docs/cli/init.md
+++ b/en/docs/cli/init.md
@@ -83,6 +83,16 @@ success Saved package.json
 ✨  Done in 121.53s.
 ```
 
+##### Setting defaults for  `yarn init` <a class="toc" id="toc-yarn-init-defaults" href="#toc-yarn-init-defaults"></a>
+
+The following [config](./config) variables can be used to customize the defaults for `yarn init`:
+
+ * init-author-name
+ * init-author-email
+ * init-author-url
+ * init-version
+ * init-license
+
 ##### `yarn init --yes/-y` <a class="toc" id="toc-yarn-init-yes-y" href="#toc-yarn-init-yes-y"></a>
 
 This command skips the interactive session mentioned above and generates a


### PR DESCRIPTION
The list of variables was found by reviewing the source code for the `init` command.