### PR TITLE
Fix #294: Validate  value provided to --version before using it.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ yarn_get_tarball() {
     # Validate that the version matches MAJOR.MINOR.PATCH to avoid garbage-in/garbage-out behavior
     version=$2
     if echo $version | grep -qP "^\d+\.\d+\.\d+$"; then
-      url="https://yarnpkg.com/downloads/$version/yarn-$version.tar.gz"
+      url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
     else
       printf "$red> Version number must match MAJOR.MINOR.PATCH.$reset\n"
       exit 1;

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,14 @@ yarn_get_tarball() {
   if [ "$1" = '--nightly' ]; then
     url=https://nightly.yarnpkg.com/latest.tar.gz
   elif [ "$1" = '--version' ]; then
-    url="https://yarnpkg.com/downloads/$2/yarn-v$2.tar.gz"
+    # Validate that the version matches MAJOR.MINOR.PATCH to avoid garbage-in/garbage-out behavior
+    version=$2
+    if echo $version | grep -qP "^\d+\.\d+\.\d+$"; then
+      url="https://yarnpkg.com/downloads/$version/yarn-$version.tar.gz"
+    else
+      printf "$red> Version number must match MAJOR.MINOR.PATCH.$reset\n"
+      exit 1;
+    fi
   else
     url=https://yarnpkg.com/latest.tar.gz
   fi

--- a/install.sh
+++ b/install.sh
@@ -27,13 +27,17 @@ yarn_get_tarball() {
   fi
   # Get both the tarball and its GPG signature
   tarball_tmp=`mktemp -t yarn.XXXXXXXXXX.tar.gz`
-  curl -L -o "$tarball_tmp#1" "$url{,.asc}"
-  yarn_verify_integrity $tarball_tmp
+  if curl --fail -L -o "$tarball_tmp#1" "$url{,.asc}"; then
+    yarn_verify_integrity $tarball_tmp
 
-  printf "$cyan> Extracting to ~/.yarn...$reset\n"
-  mkdir .yarn
-  tar zxf $tarball_tmp -C .yarn --strip 1 # extract tarball
-  rm $tarball_tmp{,.asc}
+    printf "$cyan> Extracting to ~/.yarn...$reset\n"
+    mkdir .yarn
+    tar zxf $tarball_tmp -C .yarn --strip 1 # extract tarball
+    rm $tarball_tmp{,.asc}
+  else
+    printf "$red> Failed to download $url.$reset\n"
+    exit 1;
+  fi
 }
 
 # Verifies the GPG signature of the tarball


### PR DESCRIPTION
I manually tested both the success and failure cases. 

This patch uses the `--perl-regexp` option to `grep`. I did not attempt a comprehensive check of which OS versions support this flag. It is supported with the GNU grep that ships with Ubuntu 16.04. 