### PR TITLE
Replace Perl regular expression with BRE

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ yarn_get_tarball() {
   elif [ "$1" = '--version' ]; then
     # Validate that the version matches MAJOR.MINOR.PATCH to avoid garbage-in/garbage-out behavior
     version=$2
-    if echo $version | grep -qP "^\d+\.\d+\.\d+$"; then
+    if echo $version | grep -q "^\d\+\.\d\+\.\d\+$"; then
       url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
     else
       printf "$red> Version number must match MAJOR.MINOR.PATCH.$reset\n"


### PR DESCRIPTION
`-P` option for grep is not available on BSD which breaks the install.sh script on macOS when using the `--version` switch