### PR TITLE
Portability: Use more common "Extended Regex" instead of "Perl Regex"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ yarn_get_tarball() {
   elif [ "$1" = '--version' ]; then
     # Validate that the version matches MAJOR.MINOR.PATCH to avoid garbage-in/garbage-out behavior
     version=$2
-    if echo $version | grep -qP "^\d+\.\d+\.\d+$"; then
+    if echo $version | grep -qE "^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$"; then
       url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
     else
       printf "$red> Version number must match MAJOR.MINOR.PATCH.$reset\n"


### PR DESCRIPTION
This fixes `yarn install --version` on with BSD grep, used by macOS.

This pull request is an alternative to PR #298, which did not work on Ubuntu Linux.