### PR TITLE
Use windows path separator in appveyor cache

### DIFF
--- a/en/docs/_ci/appveyor.md
+++ b/en/docs/_ci/appveyor.md
@@ -7,5 +7,5 @@ your `appveyor.yml`:
 
 ```yml
 cache:
- - "%LOCALAPPDATA%/Yarn"
+ - "%LOCALAPPDATA%\\Yarn"
 ```


### PR DESCRIPTION
Forward slash gives me `Cache 'C:\Users\appveyor\AppData\Local/Yarn' - Calculating checksum...Error calculating CRC32 for C:\Users\appveyor\AppData\Local/Yarn\cache\npm-abab-1.0.3\.yarn-metadata.json: The filename, directory name, or volume label syntax is incorrect`