### PR TITLE
Dev: `jekyll serve` perf improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install: test-bundler
 	@bundle install
 
 serve: test-jekyll
-	@jekyll serve
+	@jekyll serve --incremental
 
 build: test-jekyll
 	@jekyll build

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ make serve
 On Windows, `make` is not available, so you need to execute `bundle` and `jekyll` directly:
 ```sh
 bundle install
-bundle exec jekyll serve
+bundle exec jekyll serve --incremental
 ```
 
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,8 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - Makefile
+  - _sass/bootstrap
+  - .sass-cache
 
 include:
   - _redirects


### PR DESCRIPTION
Hey guys,

I've recently started playing with Yarn's website and I was surprised by Jekyll's build time and the overall poor dev experience while updating a page.

Here are 2 small things making the build time after each save going down from ~10 to <2 sec:
 - ignore .sass-cache/ and _saas/bootstrap from the watch list
 - enable Jerkyl's incremental build (regenerate only what has changed)

Before:

```
    Server address: http://127.0.0.1:4000/
  Server running... press ctrl-c to stop.
      Regenerating: 1 file(s) changed at 2016-12-18 11:34:13 ...done in 9.677989 seconds.
```

After:

```
    Server address: http://127.0.0.1:4000/
  Server running... press ctrl-c to stop.
      Regenerating: 1 file(s) changed at 2016-12-18 11:35:16 ...done in 1.73356 seconds.
```

Hope that helps :)