### PR TITLE
docs(search): only init docsearch when relevant

### DIFF
--- a/_includes/docsearch.html
+++ b/_includes/docsearch.html
@@ -1,0 +1,11 @@
+{% comment %}
+This is Algolia docsearch, search of the documentation. See https://community.algolia.com/docsearch/
+Scripts are added in the en/docs/index.html page
+{% endcomment %}
+
+<div class="row">
+  <div class="col-xs-12 col-lg-6 push-lg-3 mb-4 search">
+    <label class="search-label sr-only" for="algolia-doc-search" >Search documentation</label>
+    <input class="search-input form-control" id="algolia-doc-search" type="search" placeholder="Search documentation"/>
+  </div>
+</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,12 +21,6 @@
         <span class="footer-item"><a href="{{url_base}}/org/translations">{{i18n.site_edit_this_page}}</a></span>
       {% endif %}
     </div>
-
-    {% comment %}
-    For Algolia search
-    {% endcomment %}
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
-    <script type="text/javascript" src="/js/docsearch.js"></script>
   </footer>
 </div>
 <script>

--- a/en/docs/index.html
+++ b/en/docs/index.html
@@ -1,18 +1,16 @@
 ---
 id: docs_index
 layout: page
+scripts:
+  - https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js
+  - /js/docsearch.js
 ---
 
 {% include vars.html %}
 
 {% assign guides_size = site.data.guides | size | minus: 1 %}
 
-<div class="row">
-  <div class="col-xs-12 col-lg-6 push-lg-3 mb-4 search">
-    <label class="search-label sr-only" for="algolia-doc-search" >Search documentation</label>
-    <input class="search-input form-control" id="algolia-doc-search" type="search" placeholder="Search documentation"/>
-  </div>
-</div>
+{% include docsearch.html %}
 
 {% for index in (0..guides_size) %}
   {% assign index_mod = index | modulo: 3 %}


### PR DESCRIPTION
Previously we were instantiating docsearch on every page resulting in
console errors.

![2016-12-20-184441_1444x763_scrot](https://cloud.githubusercontent.com/assets/123822/21385094/8260fb68-c76d-11e6-81d6-7bc0b0ffe0e6.png)
