### PR TITLE
Mention prefix option for yarn global add command

### DIFF
--- a/en/docs/cli/global.md
+++ b/en/docs/cli/global.md
@@ -15,14 +15,16 @@ layout: guide
 This is useful for developer tooling that is not part of any individual project but instead is used for local commands. One such example is [create-react-app](https://github.com/facebookincubator/create-react-app) which can be installed globally like this:
 
 ```sh
-$ yarn global add create-react-app
+$ yarn global add create-react-app --prefix /usr/local
 # the `create-react-app` command is now available globally:
+$ which create-react-app
+$ /usr/local/bin/create-react-app
 $ create-react-app
 ````
 
 Read more about the commands that can be used together with `yarn global`:
 
-- [`yarn add`]({{url_base}}/docs/cli/add): add a package to use in your current package.
+- [`yarn add`]({{url_base}}/docs/cli/add): add a package to use in your current package. 
 - [`yarn bin`]({{url_base}}/docs/cli/bin): displays the location of the yarn bin folder.
 - [`yarn ls`]({{url_base}}/docs/cli/ls): list installed packages.
 - [`yarn remove`]({{url_base}}/docs/cli/remove): remove a package that will no longer be used in your current package.


### PR DESCRIPTION
--prefix option for yarn global command (https://github.com/yarnpkg/yarn/pull/1654) was not mentioned in documentation for yarn global command. Also this option is not applicable for yarn add command. This PR will help users to find out common usage to install a common package globally to a specific directory.