### PR TITLE
Rename to list.md and change "ls" to "list"

### DIFF
--- a/en/docs/cli/list.md
+++ b/en/docs/cli/list.md
@@ -1,35 +1,35 @@
 ---
-id: docs_cli_ls
+id: docs_cli_list
 guide: docs_cli
 layout: guide
 ---
 
 <p class="lead">List installed packages.</p>
 
-##### `yarn ls` <a class="toc" id="toc-yarn-ls" href="#toc-yarn-ls"></a>
+##### `yarn list` <a class="toc" id="toc-yarn-list" href="#toc-yarn-list"></a>
 
 ```sh
-yarn ls
+yarn list
 ```
 
-The `yarn ls` command mimics the expected Unix behavior of listing. In Yarn, the `ls` 
+The `yarn list` command mimics the expected Unix behavior of listing. In Yarn, the `ls` 
 command lists all dependencies for the current working directory by referencing all 
 package manager meta data files, which includes a project's dependencies.
 
 ```
-yarn ls vx.x.x
+yarn list vx.x.x
 ├─ package-1@1.3.3
 ├─ package-2@5.0.9
 │  └─ package-3@^2.1.0
 └─ package-3@2.7.0
 ```
 
-##### `yarn ls [--depth]` <a class="toc" id="toc-yarn-ls-depth" href="#toc-yarn-ls-depth"></a>
+##### `yarn list [--depth]` <a class="toc" id="toc-yarn-ls-depth" href="#toc-yarn-ls-depth"></a>
 
 By default, all packages and their dependencies will be displayed. To restrict the depth of the
-dependencies, you can add a flag, `--depth`, along with the desired level to the `ls` command. 
+dependencies, you can add a flag, `--depth`, along with the desired level to the `list` command. 
 
 ```
-yarn ls --depth=0
+yarn list --depth=0
 ```
 Keep in mind, levels are zero-indexed.


### PR DESCRIPTION
current version v0.18.1 links to https://yarnpkg.com/en/docs/cli/list when you run ls command, which is a 404.

the documentation needs to reflect the change from ls to list.