### PR TITLE
add a page title to the /search page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
     <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/assets/og_image.png" />
     <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description | strip_html | strip_newlines }}{% endif %}" />
 
-    <title>{% if page.layout == "post" %}{{page.title}} | {{ i18n.blog_title }}{% elsif page.id %}{{ i18n[page.id] }} | {{ i18n.site_title }}{% else %}{{ i18n.site_title }}{% endif %}</title>
+    <title>{% if page.layout == "post" %}{{page.title}} | {{ i18n.blog_title }}{% elsif page.title %}{{page.title}} | {{ i18n.site_title }}{% elsif page.id %}{{ i18n[page.id] }} | {{ i18n.site_title }}{% else %}{{ i18n.site_title }}{% endif %}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ i18n.site_description }}{% endif %}">
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
it wasn't showing up before, because the layout file didn't have a case for a non-blogpost that had a title, so now there's another condition for that.

see #331 where a page.title was added to that page