### PR TITLE
ci: Update yarn cache directory

### DIFF
--- a/en/docs/_ci/circle.md
+++ b/en/docs/_ci/circle.md
@@ -9,7 +9,7 @@ dependencies:
     - sudo apt-get update -qq
     - sudo apt-get install -y -qq yarn
   cache_directories:
-    - ~/.yarn-cache
+    - ~/.cache/yarn
   override:
     - yarn install
 ```

--- a/en/docs/_ci/travis.md
+++ b/en/docs/_ci/travis.md
@@ -19,7 +19,7 @@ before_install: # if "install" is overridden
   - sudo apt-get install -y -qq yarn
 cache:
   directories:
-  - $HOME/.yarn-cache
+  - $HOME/.cache/yarn
 ```
 
 {% include_relative _ci/deb-specific-version.md %}


### PR DESCRIPTION
yarn is [now cached in ~/.cache/yarn](https://github.com/yarnpkg/yarn/blob/a1192e596b85acb2f63daa1cbf30e662c2125310/src/constants.js#L41), not ~/.yarn-cache.