### PR TITLE
#339 Add note explaining no self-update in 0.18.1

### DIFF
--- a/en/docs/cli/self-update.md
+++ b/en/docs/cli/self-update.md
@@ -8,6 +8,6 @@ layout: guide
 
 ##### `yarn self-update` <a class="toc" id="toc-yarn-self-update" href="#toc-yarn-self-update"></a>
 
-*Note: `self-update` is not available in version 0.18.1, which means updates must be done manually. See <a href="https://github.com/yarnpkg/yarn/issues/1139">issue #1139</a> for details.*
+*Note: `self-update` is currently not available, which means updates must be done manually. See <a href="https://github.com/yarnpkg/yarn/issues/1139">issue #1139</a> for details.*
 
 This command is used to update Yarn to the latest available version.

--- a/en/docs/cli/self-update.md
+++ b/en/docs/cli/self-update.md
@@ -8,4 +8,6 @@ layout: guide
 
 ##### `yarn self-update` <a class="toc" id="toc-yarn-self-update" href="#toc-yarn-self-update"></a>
 
+*Note: `self-update` is not available in version 0.18.1, which means updates must be done manually. See <a href="https://github.com/yarnpkg/yarn/issues/1139">issue #1139</a> for details.*
+
 This command is used to update Yarn to the latest available version.


### PR DESCRIPTION
The self-update feature was removed pending a more robust
implementation. At present, it's not clear from the CLI or otherwise
that self-update was removed. This gives an indication in the
documentation that at least the user is not using it incorrectly.