### PR TITLE
feat(search): Also highlight description

### DIFF
--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -178,6 +178,10 @@ $ais-muted-color: rgba(black,.5);
       max-width: 100%;
     }
 
+    em {
+      border-bottom: dotted 1px;
+    }
+
     &::first-letter {
       text-transform: uppercase
     }


### PR DESCRIPTION
Description now shows the query matches in an highlighted fashion like
others fields are.

**Before**
![image](https://cloud.githubusercontent.com/assets/123822/21753527/5aa7acbc-d5ef-11e6-8d4b-4da535cdfab7.png)

**After**
![image](https://cloud.githubusercontent.com/assets/123822/21753531/715c1f56-d5ef-11e6-993e-38d6c4504aa5.png)
