### PR TITLE
Add RC to website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,12 @@ github_username:  yarnpkg
 # Thanks!
 ###
 latest_version: 0.18.1 # Look up ^
+latest_rc_version: 0.19.0
+
+# Whether to show the RC version on the site. Set this to false if the latest
+# stable version is newer than the RC (ie. if an RC has not been released since
+# the most recent stable version).
+show_rc: true
 
 gacode: "UA-85522875-1"
 

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -9,6 +9,8 @@ site_nav_getting_started: Getting Started
 site_nav_documentation: Docs
 site_nav_packages: Packages
 site_nav_blog: Blog
+site_nav_stable_version: Stable
+site_nav_rc_version: Release Candidate
 
 site_bsd_license: Distributed under BSD License
 site_code_of_conduct: Code of Conduct

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -76,9 +76,15 @@
 
         <li class="nav-item">
           <span class="sr-only">The current version of Yarn is</span>
+          Stable:
           <strong class="navbar-text">
             v{{site.latest_version}}
           </strong>
+          {% if site.show_rc %}
+            <span aria-hidden="true">&bull;</span>
+            <abbr title="Release Candidate">RC</abbr>:
+            <strong>v{{site.latest_rc_version}}</strong>
+          {% endif %}
         </li>
       </ul>
     </div>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -76,13 +76,13 @@
 
         <li class="nav-item">
           <span class="sr-only">The current version of Yarn is</span>
-          Stable:
+          {{i18n.site_nav_stable_version}}:
           <strong class="navbar-text">
             v{{site.latest_version}}
           </strong>
           {% if site.show_rc %}
             <span aria-hidden="true">&bull;</span>
-            <abbr title="Release Candidate">RC</abbr>:
+            <abbr title="{{i18n.site_nav_rc_version}}">RC</abbr>:
             <strong>v{{site.latest_rc_version}}</strong>
           {% endif %}
         </li>

--- a/_redirects
+++ b/_redirects
@@ -10,6 +10,15 @@ layout: null
 /latest.deb        https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/yarn_{{site.latest_version}}_all.deb      302
 /latest.rpm        https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_version}}/yarn-{{site.latest_version}}-1.noarch.rpm 302
 
+# Nice short URLs for latest RC
+# If Netlify supported regular expressions in their rewrite rules, these could
+# simply be a part of the rules above. Alas, they don't support it :(
+/latest-rc.tar.gz     https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_rc_version}}/yarn-v{{site.latest_rc_version}}.tar.gz      302
+/latest-rc.tar.gz.asc https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_rc_version}}/yarn-v{{site.latest_rc_version}}.tar.gz.asc  302
+/latest-rc.msi        https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_rc_version}}/yarn-{{site.latest_rc_version}}.msi          302
+/latest-rc.deb        https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_rc_version}}/yarn_{{site.latest_rc_version}}_all.deb      302
+/latest-rc.rpm        https://github.com/yarnpkg/yarn/releases/download/v{{site.latest_rc_version}}/yarn-{{site.latest_rc_version}}-1.noarch.rpm 302
+
 /en  /  302
 
 {% for language in site.data.languages %}

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,8 @@ yarn_get_tarball() {
   printf "$cyan> Downloading tarball...$reset\n"
   if [ "$1" = '--nightly' ]; then
     url=https://nightly.yarnpkg.com/latest.tar.gz
+  elif [ "$1" = '--rc' ]; then
+    url=https://yarnpkg.com/latest-rc.tar.gz
   elif [ "$1" = '--version' ]; then
     # Validate that the version matches MAJOR.MINOR.PATCH to avoid garbage-in/garbage-out behavior
     version=$2
@@ -167,6 +169,10 @@ yarn_install() {
       elif [ "$1" = '--version' ]; then
         specified_version=$2
         version_type='specified'
+      elif [ "$1" = '--rc' ]; then
+        latest_url=https://yarnpkg.com/latest-rc-version
+        specified_version=`curl -sS $latest_url`
+        version_type='rc'
       else
         latest_url=https://yarnpkg.com/latest-version
         specified_version=`curl -sS $latest_url`

--- a/latest-rc-version
+++ b/latest-rc-version
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{{site.latest_rc_version}}


### PR DESCRIPTION
- Add `/latest-rc-version` endpoint to return version number
- Add `--rc` flag to installation script
- Add redirects for RC version (eg. `/latest-rc.tar.gz`)
- Show RC version number on site
   ![chrome_10-21 40 55](https://cloud.githubusercontent.com/assets/91933/21836919/53301552-d77d-11e6-8d8f-40e48e6d85f6.png)


I'll make a script that automatically bumps this version number on new releases, based on whether the GitHub release is marked as stable or not.

References https://github.com/yarnpkg/yarn/issues/2161

cc @bestander 