### PR TITLE
Docs: Consistent use of Upgrading / upgrade

### DIFF
--- a/en/docs/usage.md
+++ b/en/docs/usage.md
@@ -24,7 +24,7 @@ yarn add [package]@[version]
 yarn add [package]@[tag]
 ```
 
-**Updating a dependency**
+**Upgrading a dependency**
 
 ```sh
 yarn upgrade [package]


### PR DESCRIPTION
Given that the command is called `upgrade`, the title should echo this.