### PR TITLE
fix: do not fail if .yarn dir exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ yarn_get_tarball() {
     yarn_verify_integrity $tarball_tmp
 
     printf "$cyan> Extracting to ~/.yarn...$reset\n"
-    mkdir -p .yarn
+    mkdir .yarn
     tar zxf $tarball_tmp -C .yarn --strip 1 # extract tarball
     rm $tarball_tmp{,.asc}
   else
@@ -182,6 +182,7 @@ yarn_install() {
       yarn_alt_version=`yarn --version`
       if [ "$specified_version" = "$yarn_version" -o "$specified_version" = "$yarn_alt_version" ]; then
         printf "$green> Yarn is already at the $specified_version version.$reset\n"
+        exit 0
       else
         rm -rf "$HOME/.yarn"
       fi

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ yarn_get_tarball() {
     yarn_verify_integrity $tarball_tmp
 
     printf "$cyan> Extracting to ~/.yarn...$reset\n"
-    mkdir .yarn
+    mkdir -p .yarn
     tar zxf $tarball_tmp -C .yarn --strip 1 # extract tarball
     rm $tarball_tmp{,.asc}
   else


### PR DESCRIPTION
Currently, when running the installer twice from the same dir, the following error occurs:

```
Installing Yarn!
/var/lib/buildkite-agent/.yarn/bin/yarn
> Yarn is already at the 0.19.1 version.
> Downloading tarball...
 
[1/2]: https://yarnpkg.com/latest.tar.gz --> /tmp/yarn.tar.gz.iSzFfDLgpA
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    92  100    92    0     0    667      0 --:--:-- --:--:-- --:--:--   671
  0     0    0   595    0     0   3227      0 --:--:-- --:--:-- --:--:--  3227
100 3416k  100 3416k    0     0  9290k      0 --:--:-- --:--:-- --:--:-- 75.4M
 
[2/2]: https://yarnpkg.com/latest.tar.gz.asc --> /tmp/yarn.tar.gz.iSzFfDLgpA.asc
100    96  100    96    0     0   1561      0 --:--:-- --:--:-- --:--:--  1561
  0     0    0   600    0     0   6245      0 --:--:-- --:--:-- --:--:--  6245
100   900  100   900    0     0   8335      0 --:--:-- --:--:-- --:--:--  8335
> Verifying integrity...
gpg: Signature made Mon Jan 16 23:45:03 2017 UTC using RSA key ID FD2497F5
gpg: Good signature from "Yarn Packaging <yarn@dan.cx>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 72EC F46A 56B4 AD39 C907  BBB7 1646 B01B 86E5 0310
     Subkey fingerprint: 6A01 0C51 6600 6599 AA17  F081 46C2 130D FD24 97F5
> GPG signature looks good
> Extracting to ~/.yarn...
mkdir: cannot create directory '.yarn': File exists
```