### PR TITLE
ci/travis: Use yarn's cache directive in examples

### DIFF
--- a/lang/en/docs/_ci/travis.md
+++ b/lang/en/docs/_ci/travis.md
@@ -18,8 +18,7 @@ before_install: # if "install" is overridden
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq yarn
 cache:
-  directories:
-  - $HOME/.cache/yarn
+  yarn: true
 ```
 
 {% include_relative _ci/deb-specific-version.md %}
@@ -34,4 +33,6 @@ sudo: false
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
+cache:
+  yarn: true
 ```


### PR DESCRIPTION
Reference: [Travis's node_js doc](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Travis-CI-supports-yarn).