### PR TITLE
Update `yarn list` command docs

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -126,7 +126,7 @@ docs_cli_licenses: yarn licenses
 docs_cli_link: yarn link
 docs_cli_login: yarn login
 docs_cli_logout: yarn logout
-docs_cli_ls: yarn ls
+docs_cli_ls: yarn list
 docs_cli_outdated: yarn outdated
 docs_cli_owner: yarn owner
 docs_cli_pack: yarn pack

--- a/en/docs/cli/global.md
+++ b/en/docs/cli/global.md
@@ -24,8 +24,8 @@ $ create-react-app
 
 Read more about the commands that can be used together with `yarn global`:
 
-- [`yarn add`]({{url_base}}/docs/cli/add): add a package to use in your current package. 
+- [`yarn add`]({{url_base}}/docs/cli/add): add a package to use in your current package.
 - [`yarn bin`]({{url_base}}/docs/cli/bin): displays the location of the yarn bin folder.
-- [`yarn ls`]({{url_base}}/docs/cli/ls): list installed packages.
+- [`yarn list`]({{url_base}}/docs/cli/ls): list installed packages.
 - [`yarn remove`]({{url_base}}/docs/cli/remove): remove a package that will no longer be used in your current package.
 - [`yarn upgrade`]({{url_base}}/docs/cli/upgrade): upgrades packages to their latest version based on the specified range.


### PR DESCRIPTION
The `ls` documentation is currently incorrect.
`yarn ls` -> `yarn list`

There could be more effort put into this and in the yarn package itself (i.e. `yarn global ls` is still the norm).