### PR TITLE
Adds a link to the corresponding GitHub release page in the nav

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -78,12 +78,18 @@
           <span class="sr-only">The current version of Yarn is</span>
           {{i18n.site_nav_stable_version}}:
           <strong class="navbar-text">
-            v{{site.latest_version}}
+            <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_version}}">
+              v{{site.latest_version}}
+            </a>
           </strong>
           {% if site.show_rc %}
             <span aria-hidden="true">&bull;</span>
-            <abbr title="{{i18n.site_nav_rc_version}}">RC</abbr>:
-            <strong>v{{site.latest_rc_version}}</strong>
+              <abbr title="{{i18n.site_nav_rc_version}}">RC</abbr>:
+              <strong>
+                <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_rc_version}}">
+                  v{{site.latest_rc_version}}
+                </a>
+              </strong>
           {% endif %}
         </li>
       </ul>


### PR DESCRIPTION
I saw this, and was like "Awesome 🌟"

![screen shot 2017-01-24 at 10 33 28 am](https://cloud.githubusercontent.com/assets/49038/22253701/9b0af1e6-e220-11e6-8cff-bfd19171ea29.png)

So I went to the site and tried to click on this:

![screen shot 2017-01-24 at 10 27 58 am](https://cloud.githubusercontent.com/assets/49038/22253681/869a6d04-e220-11e6-9fe9-562722d2402f.png)

and it didn't work, so I figured I could contribute back 💯 

![screen shot 2017-01-24 at 10 30 23 am](https://cloud.githubusercontent.com/assets/49038/22253737/b6393ebe-e220-11e6-9f7a-5e7913e331fb.png)

Which will take you to https://github.com/yarnpkg/yarn/releases/tag/v0.19.1