### PR TITLE
docs(search): horizontally center pagination and adjust margins

### DIFF
--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -39,6 +39,8 @@ $ais-muted-color: rgba(black,.5);
 }
 
 .ais-pagination {
+  margin: 3em 0 0 0;
+
   &--item {
     display: none;
   }

--- a/search.html
+++ b/search.html
@@ -32,7 +32,7 @@ featured_packages:
     <div id="pkg-search-results" class="col-lg-8 offset-lg-2">
       <div id="pkg-search-refinements"></div>
       <div id="pkg-search-hits"></div>
-      <div id="pkg-search-pagination" class="text-xs-center"></div>
+      <div id="pkg-search-pagination" class="text-center"></div>
     </div>
   </div>
 


### PR DESCRIPTION
Before this commit, the pagination on search results was not
centered, this looked weird.

Also adjusted margins so that pagination does not insert itself
too close to last result.