### PR TITLE
Fix install command for codeship

### DIFF
--- a/lang/en/docs/_ci/codeship.md
+++ b/lang/en/docs/_ci/codeship.md
@@ -2,7 +2,7 @@ On [Codeship](https://codeship.com/), you can install Yarn as part of your
 build by adding this to your _Setup Commands_ in your project settings:
 
 ```sh
-npm install --global yarn
+npm install yarn
 ```
 
 If you are using Codeship's


### PR DESCRIPTION
Codeship use `nvm` to choose the correct node version based on `package.json`. Globally installing on Codeship uses the system node version (0.10), which Yarn is not compatible with.