### PR TITLE
docs(search): fix empty query display

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -11,7 +11,6 @@
     indexName: 'npm-search',
     urlSync: {
       trackedParameters: ['query', 'page', 'facetsRefinements'],
-      updateOnEveryKeyStroke: false,
       threshold: 900
     },
     searchParameters: {
@@ -34,8 +33,10 @@
   });
 
   search.on('render', function () {
-    $home.hide();
-    $results.show();
+    if (search.helper.state.query !== '') {
+      $home.hide();
+      $results.show();
+    }
   });
 
   $inputClear.on('click', function () {

--- a/search.html
+++ b/search.html
@@ -2,10 +2,10 @@
 id: search
 layout: page
 stylesheets:
-  - "https://cdn.jsdelivr.net/instantsearch.js/1.10.2/instantsearch.min.css"
+  - "https://cdn.jsdelivr.net/instantsearch.js/1.10.5/instantsearch.min.css"
 scripts:
   - "https://cdn.jsdelivr.net/momentjs/2.17.1/moment.min.js"
-  - "https://cdn.jsdelivr.net/instantsearch.js/1.10.2/instantsearch-preact.js"
+  - "https://cdn.jsdelivr.net/instantsearch.js/1.10.5/instantsearch-preact.js"
   - "/js/search.js"
 title: Package Search
 featured_packages:


### PR DESCRIPTION
Before this commit when rapidly typing a letter then removing it, the
"no query" screen (search homepage) was not showing because of a race
condition.

This is now fixed, I also upgraded to latest instantsearch since the
default url sync mechanism is now the good one.

Bad behavior:
![bug-empty-query](https://cloud.githubusercontent.com/assets/123822/22694004/d3d55ff4-ed45-11e6-8124-96d4f3417835.gif)
