### PR TITLE
Finish the rename of `yarn ls` to `yarn list`.

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -81,9 +81,9 @@
   - id: docs_cli_logout
     path: /docs/cli/logout
     tags: ["cli-logout"]
-  - id: docs_cli_ls
-    path: /docs/cli/ls
-    tags: ["cli-ls"]
+  - id: docs_cli_list
+    path: /docs/cli/list
+    tags: ["cli-list"]
   - id: docs_cli_outdated
     path: /docs/cli/outdated
     tags: ["cli-outdated"]

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -126,7 +126,7 @@ docs_cli_licenses: yarn licenses
 docs_cli_link: yarn link
 docs_cli_login: yarn login
 docs_cli_logout: yarn logout
-docs_cli_ls: yarn list
+docs_cli_list: yarn list
 docs_cli_outdated: yarn outdated
 docs_cli_owner: yarn owner
 docs_cli_pack: yarn pack

--- a/_redirects
+++ b/_redirects
@@ -62,3 +62,6 @@ layout: null
 
 # Without Language
 {{redirectsBase | join: newline}}
+
+# ls was renamed to list
+/:language/docs/cli/ls   /:language/docs/cli/list 301

--- a/lang/en/docs/cli/global.md
+++ b/lang/en/docs/cli/global.md
@@ -28,6 +28,6 @@ Read more about the commands that can be used together with `yarn global`:
 
 - [`yarn add`]({{url_base}}/docs/cli/add): add a package to use in your current package. 
 - [`yarn bin`]({{url_base}}/docs/cli/bin): displays the location of the yarn bin folder.
-- [`yarn ls`]({{url_base}}/docs/cli/ls): list installed packages.
+- [`yarn list`]({{url_base}}/docs/cli/list): list installed packages.
 - [`yarn remove`]({{url_base}}/docs/cli/remove): remove a package that will no longer be used in your current package.
 - [`yarn upgrade`]({{url_base}}/docs/cli/upgrade): upgrades packages to their latest version based on the specified range.

--- a/lang/en/docs/cli/list.md
+++ b/lang/en/docs/cli/list.md
@@ -1,12 +1,12 @@
 ---
-id: docs_cli_ls
+id: docs_cli_list
 guide: docs_cli
 layout: guide
 ---
 
 <p class="lead">List installed packages.</p>
 
-##### `yarn list` <a class="toc" id="toc-yarn-ls" href="#toc-yarn-ls"></a>
+##### `yarn list` <a class="toc" id="toc-yarn-list" href="#toc-yarn-list"></a>
 
 ```sh
 yarn list
@@ -24,7 +24,7 @@ yarn list vx.x.x
 └─ package-3@2.7.0
 ```
 
-##### `yarn list [--depth]` <a class="toc" id="toc-yarn-ls-depth" href="#toc-yarn-ls-depth"></a>
+##### `yarn list [--depth]` <a class="toc" id="toc-yarn-list-depth" href="#toc-yarn-list-depth"></a>
 
 By default, all packages and their dependencies will be displayed. To restrict the depth of the
 dependencies, you can add a flag, `--depth`, along with the desired level to the `list` command. 


### PR DESCRIPTION
- #356 did not create redirect
 - #334 duplicated some work already done in #333 also did not update
   all necessary files.

Once this is merged, but #334 and #356 can be closed.