### PR TITLE
replace ./.yarn -> $HOME/.yarn

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ yarn_link() {
     echo "> If this isn't the profile of your current shell then please add the following to your correct profile:"
     printf "   $SOURCE_STR$reset\n"
 
-    version=`./.yarn/bin/yarn --version` || (
+    version=`$HOME/.yarn/bin/yarn --version` || (
       printf "$red> Yarn was installed, but doesn't seem to be working :(.$reset\n"
       exit 1;
     )


### PR DESCRIPTION
This causes the install script to fail unless the current directory is `$HOME`. This is not the case if, like me, you are running the install script as part of building a Docker image for a continuous build.

Note that all other references to `.yarn` are **already** `$HOME/.yarn`