### PR TITLE
add version flag to travis container-based builds

### DIFF
--- a/lang/en/docs/_ci/travis.md
+++ b/lang/en/docs/_ci/travis.md
@@ -31,7 +31,7 @@ For example:
 ```yaml
 sudo: false
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version {{site.latest_version}}
   - export PATH=$HOME/.yarn/bin:$PATH
 cache:
   yarn: true


### PR DESCRIPTION
The previous section of the page, "sudo-enabled builds", recommends locking the version of yarn when installing for ci. (See the deb-specific-version.md include)

No similar example is given for `container-based builds` so this simply updates that example.