### PR TITLE
feat(documentation): i18n on the docsearch

### DIFF
--- a/js/src/documentation.js
+++ b/js/src/documentation.js
@@ -4,4 +4,5 @@ docsearch({
   apiKey: '3949f721e5d8ca1de8928152ff745b28',
   indexName: 'yarnpkg',
   inputSelector: '#algolia-doc-search',
+  algoliaOptions: { facetFilters: { lang: window.i18n.active_language } },
 });


### PR DESCRIPTION
The documentation has been written in a few languages now, but was only crawled in English. 

Now the setup has been put in place for documentation in multiple languages (see https://github.com/algolia/docsearch-configs/pull/130 as well). 

The other languages can only be added as soon as this is merged.