### PR TITLE
feat(docsearch): only use active language

### DIFF
--- a/js/src/documentation.js
+++ b/js/src/documentation.js
@@ -4,5 +4,5 @@ docsearch({
   apiKey: '3949f721e5d8ca1de8928152ff745b28',
   indexName: 'yarnpkg',
   inputSelector: '#algolia-doc-search',
-  algoliaOptions: { facetFilters: { lang: window.i18n.active_language } },
+  algoliaOptions: { filters: `lang:${window.i18n.active_language}` },
 });


### PR DESCRIPTION
so the syntax changed a little as to what I expected, and this PR is needed to make sure that only the current language is shown in the result.

If the language isn't in the list of languages indexed by algolia ([docsearch-configs](https://github.com/algolia/docsearch-configs/blob/master/configs/yarnpkg.json))

cc @daniel15