### PR TITLE
Fix CircleCI doc link.

### DIFF
--- a/lang/en/docs/_ci/circle.md
+++ b/lang/en/docs/_ci/circle.md
@@ -1,1 +1,1 @@
-Yarn is pre-installed on [CircleCI](https://circleci.com/). You can quickly get up and running by following their [Yarn documentation](https://circleci.com/docs/yarn/).
+Yarn is pre-installed on [CircleCI](https://circleci.com/). You can quickly get up and running by following their [Yarn documentation](https://circleci.com/docs/1.0/yarn/).


### PR DESCRIPTION
Our Yarn doc moved. It's redirected but a direct link is better.