### PR TITLE
feat(search) only retrieve some attributes

### DIFF
--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -28,6 +28,19 @@ const Search = props => (
       hitsPerPage={5}
       // optionalFacetFilters={`name:${this.state.searchState.query}`}
       facets={['keywords']}
+      attributesToRetrieve={[
+        'name',
+        'downloadsLast30Days',
+        'humanDownloadsLast30Days',
+        'license',
+        'version',
+        'description',
+        'modified',
+        'keywords',
+        'homepage',
+        'githubRepo',
+        'owner',
+      ]}
     />
     <SearchBox
       translations={{


### PR DESCRIPTION
You don't need to fetch all of the attributes in the search (especially once the readme would be indexed), so this means the search will become slightly faster (not really noticeable to my eye, but it's the thought that counts, since #millisecondsmatter).

This PR is needed before https://github.com/algolia/npm-search/pull/23 can be merged to avoid a slowdown