### PR TITLE
Clarify that private scoped packages are not supported

### DIFF
--- a/lang/en/docs/cli/add.md
+++ b/lang/en/docs/cli/add.md
@@ -54,6 +54,8 @@ You can also specify packages from different locations:
 
 ### Caveats <a class="toc" id="toc-caveats" href="#toc-caveats"></a>
 
+Yarn does not support scoped packages at this time.
+
 If you have used a package manager like npm previously, you may be looking for
 how to add global dependencies.
 

--- a/lang/en/docs/cli/add.md
+++ b/lang/en/docs/cli/add.md
@@ -54,7 +54,7 @@ You can also specify packages from different locations:
 
 ### Caveats <a class="toc" id="toc-caveats" href="#toc-caveats"></a>
 
-Yarn does not support private scoped packages at this time.
+Yarn does not support scoped packages requiring authentication (a.k.a., private scoped packages) at this time.
 
 If you have used a package manager like npm previously, you may be looking for
 how to add global dependencies.

--- a/lang/en/docs/cli/add.md
+++ b/lang/en/docs/cli/add.md
@@ -54,7 +54,7 @@ You can also specify packages from different locations:
 
 ### Caveats <a class="toc" id="toc-caveats" href="#toc-caveats"></a>
 
-Yarn does not support scoped packages at this time.
+Yarn does not support private scoped packages at this time.
 
 If you have used a package manager like npm previously, you may be looking for
 how to add global dependencies.


### PR DESCRIPTION
Scoped packages are a pretty common use case, and searching the internet for "yarn scoped packages" brings people to issues like https://github.com/yarnpkg/yarn/issues/521 which generally end with a comment saying that scoped packages are now supported. Since they are not supported, I think adding this line to the website could save people some time.