### PR TITLE
fix(opensearch) link to /en/ by default

### DIFF
--- a/opensearch.xml
+++ b/opensearch.xml
@@ -2,7 +2,7 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>Yarn</ShortName>
   <Description>Package Search</Description>
-  <Url type="text/html" method="get" template="https://www.yarnpkg.com/packages?q={searchTerms}"/>
+  <Url type="text/html" method="get" template="https://www.yarnpkg.com/en/packages?q={searchTerms}"/>
   <InputEncoding>UTF-8</InputEncoding>
   <Image height="32" width="32" type="image/x-icon">https://yarnpkg.com/favicon.ico</Image>
 </OpenSearchDescription>


### PR DESCRIPTION
because a redirect takes you from /packages?q=whatever to /en/packages, which forgets the querystring, linking to en by default (from which you can then change your language) seems like a good solution.

see also #406 and #405