### PR TITLE
fix(search): Fix OpenSearch file in Firefox (#405)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
     <link rel="icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}" type="image/x-icon">
 
-    <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml">
+    <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Yarn">
 
     {% for stylesheet in page.stylesheets %}
       <link rel="stylesheet" href="{{stylesheet}}" />

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>Yarn</ShortName>
   <Description>Package Search</Description>


### PR DESCRIPTION
Firefox does not show the ability to add the site as a search provider when there is an xml declaration at the top of the file.

This commit removes it so that the search works with Firefox.

Also add a title to the link, as suggested by the MDN docs

Confirmed to work on localhost:4000

![opensearch_ff](https://cloud.githubusercontent.com/assets/5845924/23721130/24c3cb46-0441-11e7-81da-98aeaf52cfbc.png)
