### PR TITLE
feat(search) autoFocus SearchBox on search page

### DIFF
--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -43,6 +43,7 @@ const Search = props => (
       ]}
     />
     <SearchBox
+      autoFocus={window.location.pathname.includes('/packages')}
       translations={{
         placeholder: window.i18n.search_placeholder,
       }}


### PR DESCRIPTION
# What
This PR adds a new feature - the `<SearchBox />` component now has the `autoFocus` property when the user loads the search page. 

# Why
When I arrive at the search page from an OpenSearch search in my browser, I would like to easily continue my search experience. Say I had a typo in my search, I would like to be able to correct it. Today I have to use my mouse to click the search field, then correct it and press enter. The mouse part seems redundant, so that is what this PR addresses.

See also https://github.com/yarnpkg/website/issues/405