### PR TITLE
fix(i18n): provide a default value for scripted langs

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -278,38 +278,41 @@ ci_semaphore: Semaphore
 ci_solano: Solano
 
 search_docs: Search documentation
-search_placeholder: Search packages (i.e. babel, webpack, react…)
-search_by_algolia: Search by Algolia
-search_by_read_more: read how it works
-
-downloads_in_last_30_days: downloads in the last 30 days
-npm_page_for: 'npm page for {name}'
-github_repo_of: 'GitHub repository of {name}'
-npm: npm
-github: GitHub
-homepage: Homepage
-
 detail:
   title: Package detail
-  over_a_year_ago: over a year ago
-  less_than_a_week_ago: less than a week ago
-  one_week_ago: one week ago
-  weeks_ago: '{count} weeks ago'
-  activity: Activity
-  commits_last_three_months: Commits last 3 months
-  last_commit: Last commit
-  use_it: Use it
-  try_in_runkit: Try in RunKit
-  contributors: Contributors
-  display_full_readme: Display full readme
-  display_full_changelog: Display full changelog
-  collapse: Collapse
-  readme: readme
-  no_readme_found: no readme found 😢
-  changelog: changelog
-  popularity: Popularity
-  github_stargazers: GitHub stargazers
-  downloads_last_30_days: Downloads last 30 days
-  dependents: Dependents
-  dependencies: Dependencies
-  usage: Usage
+
+script:
+  search_placeholder: Search packages (i.e. babel, webpack, react…)
+  search_by_algolia: Search by Algolia
+  search_by_read_more: read how it works
+
+  downloads_in_last_30_days: downloads in the last 30 days
+  npm_page_for: 'npm page for {name}'
+  github_repo_of: 'GitHub repository of {name}'
+  npm: npm
+  github: GitHub
+  homepage: Homepage
+
+  detail:
+    over_a_year_ago: over a year ago
+    less_than_a_week_ago: less than a week ago
+    one_week_ago: one week ago
+    weeks_ago: '{count} weeks ago'
+    activity: Activity
+    commits_last_three_months: Commits last 3 months
+    last_commit: Last commit
+    use_it: Use it
+    try_in_runkit: Try in RunKit
+    contributors: Contributors
+    display_full_readme: Display full readme
+    display_full_changelog: Display full changelog
+    collapse: Collapse
+    readme: readme
+    no_readme_found: no readme found 😢
+    changelog: changelog
+    popularity: Popularity
+    github_stargazers: GitHub stargazers
+    downloads_last_30_days: Downloads last 30 days
+    dependents: Dependents
+    dependencies: Dependencies
+    usage: Usage

--- a/_includes/i18n-as-script.html
+++ b/_includes/i18n-as-script.html
@@ -6,7 +6,7 @@
   window.i18n.active_language = {{ vars_active_language.tag | jsonify }};
   
   // give defaults
-  for (var key in window.i18n) {
+  for (var key in i18n_default) {
     if (window.i18n.hasOwnProperty(key) === false || window.i18n[key] === null) {
       window.i18n[key] = i18n_default[key];
     }

--- a/_includes/i18n-as-script.html
+++ b/_includes/i18n-as-script.html
@@ -1,44 +1,16 @@
-{% comment %} get the current translations from Jekyll, to be used in scripts {% endcomment %}
+%} get the current translations from Jekyll, to be used in scripts %}
 <script>
-  window.i18n = {
-    url_base: {{url_base | jsonify }},
-    active_language: {{vars_active_language.tag | jsonify }},
-    search_placeholder: {{ i18n.search_placeholder | jsonify }},
-    search_by_algolia: {{ i18n.search_by_algolia | jsonify }},
-    search_by_read_more: {{ i18n.search_by_read_more | jsonify }},
-    downloads_in_last_30_days: {{ i18n.downloads_in_last_30_days | jsonify }},
-    npm_page_for: {{ i18n.npm_page_for | jsonify }},
-    github_repo_of: {{ i18n.github_repo_of | jsonify }},
-    npm: {{ i18n.npm | jsonify }},
-    github: {{ i18n.github | jsonify }},
-    homepage: {{ i18n.homepage | jsonify }},
-    detail: {
-      display_full_readme: {{ i18n.detail.display_full_readme | jsonify }},
-      display_full_changelog: {{ i18n.detail.display_full_changelog | jsonify }},
-      collapse: {{ i18n.detail.collapse | jsonify }},
-      title: {{ i18n.detail.title | jsonify}},
-      over_a_year_ago: {{ i18n.detail.over_a_year_ago | jsonify}},
-      less_than_a_week_ago: {{ i18n.detail.less_than_a_week_ago | jsonify}},
-      one_week_ago: {{ i18n.detail.one_week_ago | jsonify}},
-      weeks_ago: {{ i18n.detail.weeks_ago | jsonify}},
-      activity: {{ i18n.detail.activity | jsonify}},
-      commits_last_three_months: {{ i18n.detail.commits_last_three_months | jsonify}},
-      last_commit: {{ i18n.detail.last_commit | jsonify}},
-      use_it: {{ i18n.detail.use_it | jsonify}},
-      try_in_runkit: {{ i18n.detail.try_in_runkit | jsonify}},
-      contributors: {{ i18n.detail.contributors | jsonify}},
-      display_full_readme: {{ i18n.detail.display_full_readme | jsonify}},
-      display_full_changelog: {{ i18n.detail.display_full_changelog | jsonify}},
-      collapse: {{ i18n.detail.collapse | jsonify}},
-      readme: {{ i18n.detail.readme | jsonify}},
-      no_readme_found: {{ i18n.detail.no_readme_found | jsonify}},
-      changelog: {{ i18n.detail.changelog | jsonify}},
-      popularity: {{ i18n.detail.popularity | jsonify}},
-      github_stargazers: {{ i18n.detail.github_stargazers | jsonify}},
-      downloads_last_30_days: {{ i18n.detail.downloads_last_30_days | jsonify}},
-      dependents: {{ i18n.detail.dependents | jsonify}},
-      dependencies: {{ i18n.detail.dependencies | jsonify}},
-      usage: {{ i18n.detail.usage | jsonify}},
+  var i18n_default = {{ site.data.i18n.en.script | jsonify }};
+  window.i18n = {{ i18n.script | jsonify }};
+  window.i18n.url_base = {{ url_base | jsonify }};
+  window.i18n.active_language = {{ vars_active_language.tag | jsonify }};
+  
+  // give defaults
+  for (var key in window.i18n) {
+    if (window.i18n.hasOwnProperty(key)) {
+      if (window.i18n[key] === null) {
+        window.i18n[key] = i18n_default[key];
+      }
     }
   }
 </script>

--- a/_includes/i18n-as-script.html
+++ b/_includes/i18n-as-script.html
@@ -7,10 +7,8 @@
   
   // give defaults
   for (var key in window.i18n) {
-    if (window.i18n.hasOwnProperty(key)) {
-      if (window.i18n[key] === null) {
-        window.i18n[key] = i18n_default[key];
-      }
+    if (window.i18n.hasOwnProperty(key) === false || window.i18n[key] === null) {
+      window.i18n[key] = i18n_default[key];
     }
   }
 </script>

--- a/_includes/i18n-as-script.html
+++ b/_includes/i18n-as-script.html
@@ -1,7 +1,7 @@
 %} get the current translations from Jekyll, to be used in scripts %}
 <script>
   var i18n_default = {{ site.data.i18n.en.script | jsonify }};
-  window.i18n = {{ i18n.script | jsonify }};
+  window.i18n = {{ i18n.script | jsonify }} || {};
   window.i18n.url_base = {{ url_base | jsonify }};
   window.i18n.active_language = {{ vars_active_language.tag | jsonify }};
   


### PR DESCRIPTION
Because in some places operations like `.replace()` are used on the strings, and this doesn't work on `null`, languages that weren’t fully translated gave errors.

What’s done is to give them a default value of the English version of the text (which is a better experience anyway). 

Meanwhile I separated the values used in script from those not used in script.

(to be checked in the deploy preview, since i18n is very hard to test locally) [link](http://deploy-preview-429--yarnpkg.netlify.com/en/)

fixes #427 