### PR TITLE
fix(redirects): explicitly route /packages/ to /packages/

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -2,6 +2,7 @@
 layout: null
 ---
 /:lang/package/* /lang/:lang/package 200
+/:lang/packages/ /lang/:lang/packages 200
 
 /downloads/:version/:file https://github.com/yarnpkg/yarn/releases/download/v:version/:file
 

--- a/_redirects
+++ b/_redirects
@@ -1,8 +1,8 @@
 ---
 layout: null
 ---
-/:lang/package/* /lang/:lang/package 200
 /:lang/packages/ /lang/:lang/packages 200
+/:lang/package/* /lang/:lang/package 200
 
 /downloads/:version/:file https://github.com/yarnpkg/yarn/releases/download/v:version/:file
 


### PR DESCRIPTION
For some reason, Netlify interprets /en/packages/ to match /:lang/package/*, so this here will override that behaviour

(waiting on the deploy preview to see if it does the job)