### PR TITLE
fix(docsearch): custom styling

### DIFF
--- a/_includes/docsearch.html
+++ b/_includes/docsearch.html
@@ -4,7 +4,7 @@ Scripts are added in the en/docs/index.html page
 {% endcomment %}
 
 <div class="row">
-  <div class="col-xs-12 col-lg-6 push-lg-3 mb-4 search">
+  <div class="col-12 col-lg-6 push-lg-3 mb-4 search">
     <label class="search-label sr-only" for="algolia-doc-search">{{i18n.search_docs}}</label>
     <input class="search-input form-control" id="algolia-doc-search" type="search" placeholder="{{i18n.search_docs}}" />
   </div>

--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -398,6 +398,9 @@ $ais-muted-color: rgba(black,.5);
   }
 }
 
+.search-footer {
+  text-align: center;
+}
 
 /** Algolia Doc Search **/
 
@@ -415,8 +418,66 @@ $ais-muted-color: rgba(black,.5);
   padding: 1rem 1.5rem 1rem 2.5rem;
   background: white url('/assets/search.svg') no-repeat 1rem center;
   background-size: 1rem 1rem;
+
+  &[aria-expanded=true] {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
 }
 
-.search-footer {
-  text-align: center;
+/* Override */
+.ds-dropdown-menu {
+  min-width: auto !important;
+  width: 100% !important;
+  background-color: white;
+  border: 1px solid $yarn-blue;
+  border-bottom-right-radius: .25rem;
+  border-bottom-left-radius: .25rem;
+  border-top: none;
+}
+
+/* Bottom border of each suggestion */
+.algolia-docsearch-suggestion {
+  border-bottom-color: $yarn-blue;
+}
+
+/* Main category headers */
+.algolia-docsearch-suggestion--category-header {
+  background-color: $yarn-blue;
+}
+
+/* Highlighted search terms */
+.algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
+  color: $yarn-blue-dark;
+}
+.algolia-docsearch-suggestion--title .algolia-docsearch-suggestion--highlight,
+.algolia-docsearch-suggestion--subcategory-column .algolia-docsearch-suggestion--highlight,
+.algolia-docsearch-suggestion--subcategory-inline .algolia-docsearch-suggestion--highlight {
+  color: $yarn-blue-darker;
+}
+
+.algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight {
+  background-color: $yarn-blue-darkest;
+}
+
+/* Currently selected suggestion */
+.ds-cursor .algolia-docsearch-suggestion--content {
+  color: $yarn-blue;
+}
+
+.ds-cursor .algolia-docsearch-suggestion {
+  background: lighten($yarn-blue, 50);
+}
+
+/* For bigger screens, when displaying results in two columns */
+@media (min-width: 768px) {
+  /* Bottom border of each suggestion */
+  .algolia-docsearch-suggestion {
+    border-bottom-color: $yarn-blue;
+  }
+  /* Left column, with secondary category header */
+  .algolia-docsearch-suggestion--subcategory-column {
+    border-right-color: $yarn-blue;
+    color: $yarn-blue-dark;
+  }
 }


### PR DESCRIPTION
1. layout for the searchbox to take up all the space on layouts smaller than `-lg`
2. apply custom docsearch style again
  - this was enabled in the December version, but overriden by docsearch. Now the selector issues have been fixed and the colours have been made in such a way that they apply correctly. 

before|after
---|---
<img width="553" alt="screen shot 2017-03-26 at 15 02 16" src="https://cloud.githubusercontent.com/assets/6270048/24331464/4ae0bdf0-1235-11e7-99ce-7155178d89c5.png"> | <img width="546" alt="screen shot 2017-03-26 at 15 01 57" src="https://cloud.githubusercontent.com/assets/6270048/24331463/4aaa5c6a-1235-11e7-8eb7-d7cf83c7b88b.png">