### PR TITLE
fix broken liquid comment

### DIFF
--- a/_includes/i18n-as-script.html
+++ b/_includes/i18n-as-script.html
@@ -1,4 +1,6 @@
-%} get the current translations from Jekyll, to be used in scripts %}
+{% comment %}
+  get the current translations from Jekyll, to be used in scripts
+{% endcomment }%}
 <script>
   var i18n_default = {{ site.data.i18n.en.script | jsonify }};
   window.i18n = {{ i18n.script | jsonify }} || {};


### PR DESCRIPTION
there is broken comment showing up in index page.

it can be written in js comment `//` or liquid comment `{% comment %} {% endcomment %}`. but I thought it was originally written in liquid so I fixed it like it :)