### PR TITLE
Adding example of cli flag for dependency categories

### DIFF
--- a/lang/en/docs/usage.md
+++ b/lang/en/docs/usage.md
@@ -24,6 +24,16 @@ yarn add [package]@[version]
 yarn add [package]@[tag]
 ```
 
+**Adding a dependency to different categories of dependencies**
+
+Add to `devDependencies`, `peerDependencies`, and `optionalDependencies` respectively:
+
+```sh
+yarn add [package] --dev
+yarn add [package] --peer 
+yarn add [package] --optional
+```
+
 **Upgrading a dependency**
 
 ```sh


### PR DESCRIPTION
Adding reference examples of adding a dependency to different categories of dependencies as outlined in the MAN pages of Yarn