### PR TITLE
feat(search): more relevancy when name is concatenated

### DIFF
--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -16,6 +16,10 @@ import Results from './Results';
 import withUrlSync from './withUrlSync';
 import { algolia } from '../config';
 
+// add concatenated name for more relevance for people spelling without spaces
+// think: createreactnative instead of create-react-native-app
+const concat = string => string.replace(/[-/@_.]+/g, '');
+
 const Search = props => (
   <InstantSearch
     appId={algolia.appId}
@@ -27,7 +31,8 @@ const Search = props => (
     <Configure
       hitsPerPage={5}
       optionalFacetFilters={
-        props.searchState.query && `name:${props.searchState.query}`
+        props.searchState.query &&
+          `concatenatedName:${concat(props.searchState.query)}`
       }
       facets={['keywords']}
       attributesToRetrieve={[


### PR DESCRIPTION
One of the higher ranked searches that return no results is `creatreactnative`. Once this is merged it will match `create-react-native` etc, since the relevancy for words with special characters in it is higher. Obviously the exact name will match either first or second depending if it has more downloads.

Because both `react-native` (real one with lots of downloads) and `reactnative` exist, in this case the one with the most downloads and the same concatenated name will show up first, the one with less downloads second.

You will see the changes already live for `createreactnative`, since they are purely Algolia side, but this PR is visible with the query:

before|after
---|---
https://yarnpkg.com/en/packages?q=reactnative | https://deploy-preview-441--yarnpkg.netlify.com/en/packages?q=reactnative
<img width="1163" alt="screen shot 2017-03-29 at 13 26 52" src="https://cloud.githubusercontent.com/assets/6270048/24452428/808d213c-1483-11e7-94dd-686c6095b1e2.png"> | <img width="1158" alt="screen shot 2017-03-29 at 13 26 59" src="https://cloud.githubusercontent.com/assets/6270048/24452408/6b501ae0-1483-11e7-891a-9bff1de7554a.png"> 