### PR TITLE
docs(install): list the version on the installation page

### DIFF
--- a/_includes/version.html
+++ b/_includes/version.html
@@ -1,0 +1,17 @@
+<div class="mt-4">
+  {{i18n.site_nav_stable_version}}:
+  <strong class="navbar-text">
+    <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_version}}">
+      v{{site.latest_version}}
+    </a>
+  </strong>
+  {% if site.show_rc %}
+    <span aria-hidden="true">&bull;</span>
+    {{i18n.site_nav_rc_version}}
+    <strong>
+      <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_rc_version}}">
+        v{{site.latest_rc_version}}
+      </a>
+    </strong>
+  {% endif %}
+</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,6 +7,11 @@ layout: default
 <div class="hero">
   <div class="container">
     <h1 class="hero-text display-4">{{i18n[page.id]}}</h1>
+    {% if layout.hero_subtext %}
+      {% include {{ layout.hero_subtext }} %}
+    {% elsif page.hero_subtext %}
+      {% include {{ page.hero_subtext }} %}
+    {% endif %}
   </div>
 </div>
 

--- a/_layouts/pages/homepage.html
+++ b/_layouts/pages/homepage.html
@@ -20,23 +20,7 @@ shitty: Yes
       </span>
     </div>
 
-    <div class="mt-4">
-      {{i18n.site_nav_stable_version}}:
-      <strong class="navbar-text">
-        <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_version}}">
-          v{{site.latest_version}}
-        </a>
-      </strong>
-      {% if site.show_rc %}
-        <span aria-hidden="true">&bull;</span>
-        {{i18n.site_nav_rc_version}}
-        <strong>
-          <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_rc_version}}">
-            v{{site.latest_rc_version}}
-          </a>
-        </strong>
-      {% endif %}
-    </div>
+    {% include version.html %}
   </div>
 </div>
 

--- a/_layouts/pages/install.html
+++ b/_layouts/pages/install.html
@@ -1,5 +1,6 @@
 ---
 layout: guide
+hero_subtext: version.html
 scripts:
   - "/js/build/install.js"
 ---


### PR DESCRIPTION
closes #252

It's now possible to add any `hero_subtext` include by listing the _includes filename in the frontmatter of a layout or a page.

see http://deploy-preview-444--yarnpkg.netlify.com/en/docs/install/

![](https://cloud.githubusercontent.com/assets/6270048/24611353/1e028e0a-1882-11e7-9a80-52405bf3f72f.png)