### PR TITLE
feat(Search): link to documentation in no results

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -287,6 +287,9 @@ script:
   search_placeholder: Search packages (i.e. babel, webpack, react…)
   search_by_algolia: Search by Algolia
   search_by_read_more: read how it works
+  no_package_found: 'No package {name} was found'
+  no_results_docsearch: 'Were you looking for something in the {documentation_link}?'
+  documentation: documentation
 
   downloads_in_last_30_days: '{count} downloads in the last 30 days'
   npm_page_for: 'npm page for {name}'

--- a/js/src/lib/Search/Results.js
+++ b/js/src/lib/Search/Results.js
@@ -49,9 +49,15 @@ const Results = createConnector({
     return <span />;
   } else if (noResults) {
     body.classList.add('searching');
+    const docMessage = window.i18n.no_results_docsearch.split(/[{}]+/);
+    docMessage[docMessage.indexOf('documentation_link')] = (
+      <a href={`${window.i18n.url_base}/docs`}>{window.i18n.documentation}</a>
+    );
+
     return (
       <div className="container text-center mt-5">
-        No package {query} was found
+        <p>{window.i18n.no_package_found.replace('{name}', query)}</p>
+        <p>{docMessage.map((val, index) => <span key={index}>{val}</span>)}</p>
       </div>
     );
   } else {


### PR DESCRIPTION
We're seeing some queries that are actually meant for the documentation, like `--pure-lockfile`. To guide those people towards the documentation, a phrase is added to the bottom that links to the documentation.

To add the link to wherever it needs to be, depending on the language, another solution than the previous `.replace` had to be taken (splitting, replacing by a React element, mapping).

In the future the results of docsearch might be added in this search might be done, but that's a lot more work than this.

before|after
---|---
<img width="558" alt="screen shot 2017-04-12 at 16 51 14" src="https://cloud.githubusercontent.com/assets/6270048/24963967/4cbed512-1fa0-11e7-9aad-521540a98b41.png"> | <img width="552" alt="screen shot 2017-04-12 at 16 51 05" src="https://cloud.githubusercontent.com/assets/6270048/24963966/4cbdfdf4-1fa0-11e7-8975-9d52f209eee5.png">
