### PR TITLE
docs(install): update Arch Linux section

### DIFF
--- a/lang/en/docs/_installations/linux.md
+++ b/lang/en/docs/_installations/linux.md
@@ -36,11 +36,10 @@ sudo yum install yarn
 
 ### Arch Linux
 
-On Arch Linux yarn can be installed through the **AUR**.
+On Arch Linux, Yarn can be installed through the official package manager.
 
-If you use an [AUR Helper](https://wiki.archlinux.org/index.php/AUR_helpers) such as yaourt you can simply run: 
 ```sh
-yaourt -S yarn
+pacman -S yarn
 ```
 
 ### Solus


### PR DESCRIPTION
Update from the tool-dependent command to the standard installation step

The package is available in the official repositories since this commit:
https://git.archlinux.org/svntogit/community.git/commit/?id=1b135175a47e20d9c9fb7ccd0baec205178a9889