### PR TITLE
Fix relative/broken links in docs

### DIFF
--- a/lang/en/docs/cli/unlink.md
+++ b/lang/en/docs/cli/unlink.md
@@ -4,9 +4,11 @@ guide: docs_cli
 layout: guide
 ---
 
+{% include vars.html %}
+
 <p class="lead">Unlink a previously created symlink for a package.</p>
 
-To remove a symlinked package created with [`yarn link`](./link), `yarn unlink` can be used.
+To remove a symlinked package created with [`yarn link`]({{url_base}}/docs/cli/link), `yarn unlink` can be used.
 
 ##### `yarn unlink` <a class="toc" id="toc-yarn-unlink" href="#toc-yarn-unlink"></a>
 
@@ -18,7 +20,7 @@ To unlink a package that was symlinked during development in your project, simpl
 run `yarn unlink [package]`. You will need to run `yarn` or `yarn install` to re-install
 the package that was linked.
 
-Continued example from the [`yarn link`](./link) documentation: assume two folders
+Continued example from the [`yarn link`]({{url_base}}/docs/cli/link) documentation: assume two folders
 `react` and `react-relay` that are located next to each other with `react` linked
 into the `react-relay` project:
 
@@ -38,4 +40,4 @@ success Unregistered "react".
 
 Also see:
 
-- [`yarn link`](./link): symlink a package for local development.
+- [`yarn link`]({{url_base}}/docs/cli/link): symlink a package for local development.

--- a/lang/en/docs/installing-dependencies.md
+++ b/lang/en/docs/installing-dependencies.md
@@ -5,13 +5,15 @@ layout: guide
 additional_reading_tags: ["dependencies", "package-json", "yarn-lock", "cli-install"]
 ---
 
-If you have just checked out a package from [version control](./version-control), you will need to install those dependencies.
+{% include vars.html %}
 
-> If you are [adding dependencies](./managing-dependencies#toc-adding-a-dependency) for your project, then those dependencies are automatically installed during that process.
+If you have just checked out a package from [version control]({{url_base}}/docs/version-control), you will need to install those dependencies.
+
+> If you are [adding dependencies]({{url_base}}/docs/managing-dependencies#toc-adding-a-dependency) for your project, then those dependencies are automatically installed during that process.
 
 ### Installing Dependencies <a class="toc" id="toc-installing-dependencies" href="#toc-installing-dependencies"></a>
 
-[`yarn install`](./cli/install) is used to install all dependencies for a project. The dependencies are retrieved from your project's `package.json` file, and stored in the `yarn.lock` file.
+[`yarn install`]({{url_base}}/docs/cli/install) is used to install all dependencies for a project. The dependencies are retrieved from your project's `package.json` file, and stored in the `yarn.lock` file.
 
 When developing a package, installing dependencies is most commonly done after:
 
@@ -27,4 +29,4 @@ There are many options for installing dependencies, including:
 1. Forcing a re-download of all packages: `yarn install --force`
 1. Installing only production dependencies: `yarn install --production`
 
-See [the full list](./cli/install) of flags you can pass to `yarn install`.
+See [the full list]({{url_base}}/docs/cli/install) of flags you can pass to `yarn install`.


### PR DESCRIPTION
Stumbled upon the following two pages in the docs which contain a couple of relative/broken links when the pages are requested with a trailing slash. I have fixed these links to become absolute ones in order to be consistent with the rest of the pages.

- https://yarnpkg.com/en/docs/cli/unlink/
- https://yarnpkg.com/en/docs/installing-dependencies/

This problem is not noticeable when browsing normally on the Yarn website, because the whole navigation is working (and linked) without trailing slashes, although the `canonical` tags and therefore indexed pages always contain the trailing slash.

The localized canonicals are also a bit inconsistent. While the English docs landing page for example is reachable via `/en/docs/` _(with or without trailing slash)_, its canonical is pointing to `/lang/en/docs/`.

Maybe it might be better to reduce the number of possibilities of how to access these pages, but that's another issue; just wanted to mention this.