### PR TITLE
Add instructions to add Yarn to path on Unix/Linux/macOS

### DIFF
--- a/lang/en/docs/_installations/unix_path_setup.md
+++ b/lang/en/docs/_installations/unix_path_setup.md
@@ -3,4 +3,4 @@ To be able to run Yarn from anywhere, do the following:
 1. Add this to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.): `export PATH="$PATH:/opt/yarn-[version]/bin"` (path may vary depending on where you installed/extracted Yarn)
 1. In the terminal, log in and log out for the changes to take effect
 
-To have access to Yarn's binaries globally, you will need to set up the `PATH` environment variable in your terminal. To do this, add ``export PATH="$PATH:`yarn global bin`"`` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)
+To have access to Yarn's executables globally, you will need to set up the `PATH` environment variable in your terminal. To do this, add ``export PATH="$PATH:`yarn global bin`"`` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)

--- a/lang/en/docs/_installations/unix_path_setup.md
+++ b/lang/en/docs/_installations/unix_path_setup.md
@@ -1,3 +1,6 @@
-You will need to set up the `PATH` environment variable in your terminal to have access to Yarn's binaries globally.
+To be able to run Yarn from anywhere, do the following:
 
-Add ``export PATH="$PATH:`yarn global bin`"`` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)
+1. Add this to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.): `export PATH="$PATH:/opt/yarn-[version]/bin"` (path may vary depending on where you installed/extracted Yarn)
+1. In the terminal, log in and log out for the changes to take effect
+
+To have access to Yarn's binaries globally, you will need to set up the `PATH` environment variable in your terminal. To do this, add ``export PATH="$PATH:`yarn global bin`"`` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)

--- a/lang/en/docs/_installations/unix_path_setup.md
+++ b/lang/en/docs/_installations/unix_path_setup.md
@@ -1,6 +1,8 @@
-To be able to run Yarn from anywhere, do the following:
+If you chose manual installation, the following steps will add Yarn to path variable and run it from anywhere. 
 
-1. Add this to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.): `export PATH="$PATH:/opt/yarn-[version]/bin"` (path may vary depending on where you installed/extracted Yarn)
+Note: your profile may be in your `.profile`, `.bash_profile`, `.bashrc`, `.zshrc`, etc.
+
+1. Add this to your profile: `export PATH="$PATH:/opt/yarn-[version]/bin"` (the path may vary depending on where you extracted Yarn to)
 1. In the terminal, log in and log out for the changes to take effect
 
-To have access to Yarn's executables globally, you will need to set up the `PATH` environment variable in your terminal. To do this, add ``export PATH="$PATH:`yarn global bin`"`` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)
+To have access to Yarn's executables globally, you will need to set up the `PATH` environment variable in your terminal. To do this, add ``export PATH="$PATH:`yarn global bin`"`` to your profile.


### PR DESCRIPTION
``export PATH="$PATH:`yarn global bin`"`` doesn't work or make sense as a step right after installing/extracting yarn. I'm adding this as an equivalent to the Windows instructions underneath: 

<img width="784" alt="screen shot 2017-04-23 at 20 58 21" src="https://cloud.githubusercontent.com/assets/5951798/25316949/aef33a50-2867-11e7-8a5b-269c7604046f.png">

Feel free to correct/update the wording of the update!