### PR TITLE
Update unix_path_setup.md

### DIFF
--- a/lang/en/docs/_installations/unix_path_setup.md
+++ b/lang/en/docs/_installations/unix_path_setup.md
@@ -1,3 +1,6 @@
-You will need to set up the `PATH` environment variable in your terminal to have access to Yarn's binaries globally.
+To be able to run Yarn from anywhere, do the following:
 
-Add ``export PATH="$PATH:`yarn global bin`"`` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)
+1. Add this to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.): `export PATH="$PATH:/opt/yarn-[version]/bin"` (path may vary depending on where you installed/extracted Yarn)
+1. In the terminal, log in and log out for the changes to take effect
+
+To have access to Yarn's binaries globally, you will need to set up the `PATH` environment variable in your terminal. To do this, add ``export PATH="$PATH:`yarn global bin`"`` to your profile (this may be in your `.profile`, `.bashrc`, `.zshrc`, etc.)


### PR DESCRIPTION
``export PATH="$PATH:`yarn global bin`"` doesn't work or make sense as a step right after installing/extracting yarn. Feel free to correct/update the wording of the update!