### PR TITLE
fix(Activity): bug in commit activity

### DIFF
--- a/js/src/lib/Details/Activity.js
+++ b/js/src/lib/Details/Activity.js
@@ -18,7 +18,7 @@ const commitsPerWeekLastThreeMonths = ({ weeklyData }) =>
 
 const weeksAgoSinceLastCommit = ({ weeklyData }) =>
   formatWeeksSinceLastCommit(
-    weeklyData.reverse().findIndex(({ total }) => total !== 0)
+    weeklyData.slice().reverse().findIndex(({ total }) => total !== 0)
   );
 
 const formatWeeksSinceLastCommit = weeks => {


### PR DESCRIPTION
before: using `.reverse()` on an array that was used in other places too

It showed the most recent, but since that modifies the array 😠  it broke the other usages, namely the graph

after: `weeksSinceLastCommit` uses `.slice()` to make a copy of the array to do its calculation on, and consistenly shows the same (correct) data

https://deploy-preview-464--yarnpkg.netlify.com/en/package/react