### PR TITLE
changed 'yarn install --force' to 'yarn add --force' in docs/migratin…

### DIFF
--- a/lang/en/docs/migrating-from-npm.md
+++ b/lang/en/docs/migrating-from-npm.md
@@ -53,7 +53,7 @@ your existing `npm-shrinkwrap.json` file and check in the newly created `yarn.lo
 | `npm install --save-exact [package]`        | `yarn add [package] [--exact/-E]`           |
 | ***(N/A)***                                 | `yarn add [package] [--tilde/-T]`           |
 | `npm install --global [package]`            | `yarn global add [package]`                 |
-| `npm rebuild`                               | `yarn install --force`                      |
+| `npm rebuild`                               | `yarn add --force`                      |
 | `npm uninstall [package]`                   | ***(N/A)***                                 |
 | `npm uninstall --save [package]`            | `yarn remove [package]`                     |
 | `npm uninstall --save-dev [package]`        | `yarn remove [package]`                     |


### PR DESCRIPTION
updated documentation in migrating from npm to use 'yarn add --force' instead of  'yarn install --force' for 'npm rebuild'