### PR TITLE
feat(SEO): add a script to make sitemaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ build: test-builddeps
 
 serve-production: test-builddeps
 	@make crowdin-download
-	@NODE_ENV=production yarn run build
+	@NODE_ENV=production yarn build:production
 	@JEKYLL_ENV=production bundle exec jekyll serve
 
 build-production: test-builddeps
 	@make crowdin-download
 	@ruby ./scripts/validate-translations.rb
-	@NODE_ENV=production yarn run build
+	@NODE_ENV=production yarn build:production
 	@JEKYLL_ENV=production bundle exec jekyll build
 
 crowdin-upload: test-crowdin

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,7 @@
     <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
     <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/assets/og_image.png" />
     <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description | strip_html | strip_newlines }}{% endif %}" />
+    <meta name="google-site-verification" content="DIcCyEkVaGHm864NWzItnt2n6Gg7hz3l47RBIRyxvcQ" />
 
     <title>{% if page.layout == "post" %}{{page.title}} | {{ i18n.blog_title }}{% elsif page.title %}{{page.title}} | {{ i18n.site_title }}{% elsif page.id %}{{ i18n[page.id] }} | {{ i18n.site_title }}{% else %}{{ i18n.site_title }}{% endif %}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ i18n.site_description }}{% endif %}">

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "yarn-website",
   "version": "1.0.0",
   "devDependencies": {
+    "algolia-sitemap": "^1.0.1",
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.1",
     "babel-preset-es2015": "^6.24.0",
@@ -16,6 +17,8 @@
   },
   "scripts": {
     "build": "webpack",
+    "build:sitemaps": "./scripts/sitemaps.js",
+    "build:production": "npm run build && npm run build:sitemaps",
     "start": "webpack --watch",
     "lint:staged": "lint-staged"
   },

--- a/scripts/sitemaps.js
+++ b/scripts/sitemaps.js
@@ -6,6 +6,7 @@
 //   console.log('sitemap generation skipped');
 // } else {
 const algoliaSitemap = require('algolia-sitemap');
+const { mkdirSync } = require('fs');
 
 const algoliaConfig = {
   appId: 'OFCNCOG2CU',
@@ -29,11 +30,15 @@ function hitToParams(hit) {
   };
 }
 
+const path = `${__dirname}/../sitemaps`;
+
+mkdirSync(`${__dirname}/../sitemaps`);
+
 algoliaSitemap({
   algoliaConfig,
   sitemapLocation: {
     href: 'https://yarnpkg.com/sitemaps',
-    path: `${__dirname}/sitemaps`,
+    path,
   },
   hitToParams,
 });

--- a/scripts/sitemaps.js
+++ b/scripts/sitemaps.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+// commented out in first commit to test it on Netlify
+// will make sure that it this is only used on production deploys
+// if (process.env.CONTEXT === 'deploy-preview') {
+//   console.log('sitemap generation skipped');
+// } else {
+const algoliaSitemap = require('algolia-sitemap');
+
+const algoliaConfig = {
+  appId: 'OFCNCOG2CU',
+  apiKey: process.env.ALGOLIA_BROWSE_KEY,
+  indexName: 'npm-search',
+};
+
+function hitToParams(hit) {
+  const url = ({ lang, name }) => `https://yarnpkg.com/${lang}/package/${name}`;
+  const loc = url({ lang: 'en', name: hit.name });
+  const lastmod = new Date(hit.modified).toISOString();
+  const priority = hit.downloadsRatio;
+  return {
+    loc,
+    lastmod,
+    priority,
+    alternates: {
+      languages: ['fr', 'pt-BR', 'zh-Hans'],
+      hitToURL: lang => url({ lang, name: hit.name }),
+    },
+  };
+}
+
+algoliaSitemap({
+  algoliaConfig,
+  sitemapLocation: {
+    href: 'https://yarnpkg.com/sitemaps',
+    path: `${__dirname}/sitemaps`,
+  },
+  hitToParams,
+});
+// }

--- a/scripts/sitemaps.js
+++ b/scripts/sitemaps.js
@@ -1,45 +1,44 @@
 #!/usr/bin/env node
 
-// commented out in first commit to test it on Netlify
-// will make sure that it this is only used on production deploys
-// if (process.env.CONTEXT === 'deploy-preview') {
-//   console.log('sitemap generation skipped');
-// } else {
-const algoliaSitemap = require('algolia-sitemap');
-const { mkdirSync } = require('fs');
+if (process.env.CONTEXT === 'deploy-preview') {
+  console.log('sitemap generation skipped');
+} else {
+  const algoliaSitemap = require('algolia-sitemap');
+  const { mkdirSync } = require('fs');
 
-const algoliaConfig = {
-  appId: 'OFCNCOG2CU',
-  apiKey: process.env.ALGOLIA_BROWSE_KEY,
-  indexName: 'npm-search',
-};
-
-function hitToParams(hit) {
-  const url = ({ lang, name }) => `https://yarnpkg.com/${lang}/package/${name}`;
-  const loc = url({ lang: 'en', name: hit.name });
-  const lastmod = new Date(hit.modified).toISOString();
-  const priority = hit.downloadsRatio;
-  return {
-    loc,
-    lastmod,
-    priority,
-    alternates: {
-      languages: ['fr', 'pt-BR', 'zh-Hans'],
-      hitToURL: lang => url({ lang, name: hit.name }),
-    },
+  const algoliaConfig = {
+    appId: 'OFCNCOG2CU',
+    apiKey: process.env.ALGOLIA_BROWSE_KEY,
+    indexName: 'npm-search',
   };
+
+  function hitToParams(hit) {
+    const url = ({ lang, name }) =>
+      `https://yarnpkg.com/${lang}/package/${name}`;
+    const loc = url({ lang: 'en', name: hit.name });
+    const lastmod = new Date(hit.modified).toISOString();
+    const priority = hit.downloadsRatio;
+    return {
+      loc,
+      lastmod,
+      priority,
+      alternates: {
+        languages: ['fr', 'pt-BR', 'zh-Hans'],
+        hitToURL: lang => url({ lang, name: hit.name }),
+      },
+    };
+  }
+
+  const path = `${__dirname}/../sitemaps`;
+
+  mkdirSync(`${__dirname}/../sitemaps`);
+
+  algoliaSitemap({
+    algoliaConfig,
+    sitemapLocation: {
+      href: 'https://yarnpkg.com/sitemaps',
+      path,
+    },
+    hitToParams,
+  });
 }
-
-const path = `${__dirname}/../sitemaps`;
-
-mkdirSync(`${__dirname}/../sitemaps`);
-
-algoliaSitemap({
-  algoliaConfig,
-  sitemapLocation: {
-    href: 'https://yarnpkg.com/sitemaps',
-    path,
-  },
-  hitToParams,
-});
-// }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,13 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+algolia-sitemap@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/algolia-sitemap/-/algolia-sitemap-1.0.1.tgz#8b4b48b910f457618c3d0bb29463130703b6231c"
+  dependencies:
+    algoliasearch "^3.22.1"
+    xmlbuilder "^8.2.2"
+
 algoliasearch-helper@2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.19.0.tgz#cdc8c623720be8ff2b97216d1e57e02d9642f5a5"
@@ -3232,6 +3239,10 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+xmlbuilder@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
 
 xss@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
This will only be enabled on production deploys, but for now on this first preview too, to check if it works.

It basically browses through all Algolia records and then makes a record for each language in a sitemap.

This will after the merge be needed to be linked to Google Webmaster Tools.

see https://deploy-preview-468--yarnpkg.netlify.com/sitemaps/sitemap-index.xml for the sitemap index and https://deploy-preview-468--yarnpkg.netlify.com/sitemaps/sitemap.0.xml for an example