### PR TITLE
Add reference to `YARN_CACHE_FOLDER`

### DIFF
--- a/lang/en/docs/cli/cache.md
+++ b/lang/en/docs/cli/cache.md
@@ -29,3 +29,9 @@ You can also specify the cache directory by flag `--cache-folder`:
 ```sh
 yarn <command> --cache-folder <path>
 ```
+
+You can also specify the cache directory by environment variable `YARN_CACHE_FOLDER`:
+```sh
+YARN_CACHE_FOLDER=<path> yarn <command>
+```
+


### PR DESCRIPTION
`YARN_CACHE_FOLDER` environment variable and all other CLI flags will also read from the environment by default.