### PR TITLE
Improve the Search results

### DIFF
--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -108,32 +108,6 @@ $ais-muted-color: rgba(black,.5);
   }
 }
 
-.ais-Pagination {
-  &__root {
-    margin: 2em auto;
-    @extend .pagination;
-  }
-
-  &__item {
-    @extend .page-item;
-  }
-
-  &__itemLink {
-    @extend .page-link;
-  }
-
-  &__itemSelected {
-    @extend .active;
-  }
-
-  &__itemDisabled {
-    @extend .disabled;
-    visibility: visible;
-    opacity: .3;
-    cursor: default;
-  }
-}
-
 .ais-Hits {
   &--item {
     padding: 1.5rem 1rem 2rem;
@@ -148,6 +122,19 @@ $ais-muted-color: rgba(black,.5);
   &__empty {
     padding: 2.5rem 0 2rem;
     border-bottom: 1px solid $gray-lighter;
+  }
+}
+
+.ais-InfiniteHits {
+  &__root {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__loadMore {
+    margin: 1em auto;
+    @extend .btn;
+    @extend .btn-primary;
   }
 }
 

--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -125,19 +125,6 @@ $ais-muted-color: rgba(black,.5);
   }
 }
 
-.ais-InfiniteHits {
-  &__root {
-    display: flex;
-    flex-direction: column;
-  }
-
-  &__loadMore {
-    margin: 1em auto;
-    @extend .btn;
-    @extend .btn-primary;
-  }
-}
-
 .ais-Hit {
   &--name {
     font-size: 1.625rem;
@@ -336,6 +323,32 @@ $ais-muted-color: rgba(black,.5);
     background-image: url('/assets/search/ico-github.svg');
     width: 26px;
     height: 26px;
+  }
+}
+
+.ais-Pagination {
+  &__root {
+    margin: 2em auto;
+    @extend .pagination;
+  }
+
+  &__item {
+    @extend .page-item;
+  }
+
+  &__itemLink {
+    @extend .page-link;
+  }
+
+  &__itemSelected {
+    @extend .active;
+  }
+
+  &__itemDisabled {
+    @extend .disabled;
+    visibility: visible;
+    opacity: .3;
+    cursor: default;
   }
 }
 

--- a/js/src/lib/Search/Results.js
+++ b/js/src/lib/Search/Results.js
@@ -3,6 +3,7 @@ import createConnector from 'react-instantsearch/src/core/createConnector';
 import Hits from 'react-instantsearch/src/widgets/InfiniteHits';
 import CurrentRefinements
   from 'react-instantsearch/src/widgets/CurrentRefinements';
+import Stats from 'react-instantsearch/src/widgets/Stats';
 
 import Hit from '../Hit';
 import { isEmpty } from '../util';
@@ -11,7 +12,10 @@ const body = document.querySelector('body');
 
 const ResultsFound = () => (
   <div className="container">
-    <CurrentRefinements />
+    <div className="mx-3">
+      <CurrentRefinements />
+      <Stats />
+    </div>
     <Hits hitComponent={Hit} />
     <div className="search-footer">
       {window.i18n.search_by_algolia}

--- a/js/src/lib/Search/Results.js
+++ b/js/src/lib/Search/Results.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import createConnector from 'react-instantsearch/src/core/createConnector';
-import Hits from 'react-instantsearch/src/widgets/Hits';
-import Pagination from 'react-instantsearch/src/widgets/Pagination';
+import Hits from 'react-instantsearch/src/widgets/InfiniteHits';
 import CurrentRefinements
   from 'react-instantsearch/src/widgets/CurrentRefinements';
 
@@ -10,21 +9,14 @@ import { isEmpty } from '../util';
 
 const body = document.querySelector('body');
 
-const ResultsFound = ({ pagination }) => (
+const ResultsFound = () => (
   <div className="container">
     <CurrentRefinements />
     <Hits hitComponent={Hit} />
-    <div className="d-flex">
-      {pagination
-        ? <Pagination showFirst={false} showLast={false} scrollTo={true} />
-        : <div style={{ height: '3rem' }} />}
-    </div>
     <div className="search-footer">
       {window.i18n.search_by_algolia}
       {' - '}
-      <a
-        href="https://discourse.algolia.com/t/2016-algolia-community-gift-yarn-package-search/319"
-      >
+      <a href="https://discourse.algolia.com/t/2016-algolia-community-gift-yarn-package-search/319">
         {window.i18n.search_by_read_more}
       </a>
       .
@@ -35,15 +27,12 @@ const ResultsFound = ({ pagination }) => (
 const Results = createConnector({
   displayName: 'ConditionalResults',
   getProvidedProps(props, searchState, searchResults) {
-    const pagination = searchResults.results
-      ? searchResults.results.nbPages > 1
-      : false;
     const noResults = searchResults.results
       ? searchResults.results.nbHits === 0
       : false;
-    return { query: searchState.query, noResults, pagination };
+    return { query: searchState.query, noResults };
   },
-})(({ noResults, pagination, query }) => {
+})(({ noResults, query }) => {
   if (isEmpty(query)) {
     body.classList.remove('searching');
     return <span />;
@@ -62,7 +51,7 @@ const Results = createConnector({
     );
   } else {
     body.classList.add('searching');
-    return <ResultsFound pagination={pagination} />;
+    return <ResultsFound />;
   }
 });
 

--- a/js/src/lib/Search/Results.js
+++ b/js/src/lib/Search/Results.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import createConnector from 'react-instantsearch/src/core/createConnector';
-import Hits from 'react-instantsearch/src/widgets/InfiniteHits';
+import Hits from 'react-instantsearch/src/widgets/Hits';
+import Pagination from 'react-instantsearch/src/widgets/Pagination';
 import CurrentRefinements
   from 'react-instantsearch/src/widgets/CurrentRefinements';
 import Stats from 'react-instantsearch/src/widgets/Stats';
@@ -10,13 +11,18 @@ import { isEmpty } from '../util';
 
 const body = document.querySelector('body');
 
-const ResultsFound = () => (
+const ResultsFound = ({ pagination }) => (
   <div className="container">
     <div className="mx-3">
       <CurrentRefinements />
       <Stats />
     </div>
     <Hits hitComponent={Hit} />
+    <div className="d-flex">
+      {pagination
+        ? <Pagination showFirst={false} showLast={false} scrollTo={true} />
+        : <div style={{ height: '3rem' }} />}
+    </div>
     <div className="search-footer">
       {window.i18n.search_by_algolia}
       {' - '}
@@ -31,12 +37,15 @@ const ResultsFound = () => (
 const Results = createConnector({
   displayName: 'ConditionalResults',
   getProvidedProps(props, searchState, searchResults) {
+    const pagination = searchResults.results
+      ? searchResults.results.nbPages > 1
+      : false;
     const noResults = searchResults.results
       ? searchResults.results.nbHits === 0
       : false;
-    return { query: searchState.query, noResults };
+    return { query: searchState.query, noResults, pagination };
   },
-})(({ noResults, query }) => {
+})(({ noResults, query, pagination }) => {
   if (isEmpty(query)) {
     body.classList.remove('searching');
     return <span />;
@@ -55,7 +64,7 @@ const Results = createConnector({
     );
   } else {
     body.classList.add('searching');
-    return <ResultsFound />;
+    return <ResultsFound pagination={pagination} />;
   }
 });
 

--- a/js/src/lib/Search/withUrlSync.js
+++ b/js/src/lib/Search/withUrlSync.js
@@ -2,16 +2,23 @@ import React, { Component } from 'react';
 import qs from 'qs';
 
 const updateAfter = 700;
-const searchStateToQueryString = searchState => ({ q: searchState.query });
+const searchStateToQueryString = searchState => ({
+  q: searchState.query,
+  p: searchState.page,
+});
 
 const searchStateToUrl = searchState =>
   (searchState
     ? `${window.i18n.url_base}/packages?${qs.stringify(searchStateToQueryString(searchState))}`
     : '');
 
-const queryStringToSearchState = queryString => ({
-  query: qs.parse(queryString).q,
-});
+const queryStringToSearchState = queryString => {
+  const { p, q } = qs.parse(queryString);
+  return {
+    query: q,
+    page: p,
+  };
+};
 
 const originalPathName = location.pathname;
 

--- a/js/src/lib/Search/withUrlSync.js
+++ b/js/src/lib/Search/withUrlSync.js
@@ -2,17 +2,12 @@ import React, { Component } from 'react';
 import qs from 'qs';
 
 const updateAfter = 700;
-const searchStateToQueryString = searchState => ({
-  q: searchState.query,
-  p: searchState.page,
-});
+const searchStateToQueryString = searchState => ({ q: searchState.query });
 
 const searchStateToUrl = searchState =>
-  searchState
-    ? `${window.i18n.url_base}/packages?${qs.stringify(
-        searchStateToQueryString(searchState),
-      )}`
-    : '';
+  (searchState
+    ? `${window.i18n.url_base}/packages?${qs.stringify(searchStateToQueryString(searchState))}`
+    : '');
 
 const queryStringToSearchState = queryString => ({
   query: qs.parse(queryString).q,
@@ -45,20 +40,17 @@ export default App => class extends Component {
         window.history.pushState(
           null,
           'Search packages | Yarn',
-          originalPathName,
+          originalPathName
         );
       }
     } else {
-      this.debouncedSetState = setTimeout(
-        () => {
-          window.history.pushState(
-            searchState,
-            'Search packages | Yarn',
-            searchStateToUrl(searchState),
-          );
-        },
-        updateAfter,
-      );
+      this.debouncedSetState = setTimeout(() => {
+        window.history.pushState(
+          searchState,
+          'Search packages | Yarn',
+          searchStateToUrl(searchState)
+        );
+      }, updateAfter);
     }
 
     this.setState({ searchState });


### PR DESCRIPTION
1. Use infinite hits instead of pagination
  - the actual page number doesn't really matter much
  - move the page number out of the URL
    - UX for landing on a page is weird
    - we didn't use that parameter in showing the results
2. Show number of results
  - more useful than the pagination, since it's a number
  - also shows the ms it takes to do this request 

![2017-05-03 10_14_04](https://cloud.githubusercontent.com/assets/6270048/25653260/7823562c-2fec-11e7-83b5-20d1e3d18738.gif)

https://deploy-preview-478--yarnpkg.netlify.com/en/