### PR TITLE
Fix syntax highlighting of example output for `yarn why`

### DIFF
--- a/lang/en/docs/cli/why.md
+++ b/lang/en/docs/cli/why.md
@@ -13,8 +13,10 @@ other packages depend upon it, for example, or whether it was explicitly marked
 as a dependency in the `package.json` manifest.
 
 ```sh
-$ yarn why jest
+yarn why jest
+```
 
+```
 yarn why vx.x.x
 [1/4] 🤔  Why do we have the module "jest"...?
 [2/4] 🚚  Initialising dependency graph...


### PR DESCRIPTION
This style of markup for command examples was copied from `version.md`.

The current rendered version: https://yarnpkg.com/en/docs/cli/why