### PR TITLE
Use treeshook version of react-instantsearch

### DIFF
--- a/js/src/lib/Hit/index.js
+++ b/js/src/lib/Hit/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
-import Highlight from 'react-instantsearch/src/widgets/Highlight';
+import { Highlight } from 'react-instantsearch/dom';
 import {
   getDownloadBucket,
   formatKeywords,

--- a/js/src/lib/Search/Results.js
+++ b/js/src/lib/Search/Results.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import createConnector from 'react-instantsearch/src/core/createConnector';
-import Hits from 'react-instantsearch/src/widgets/Hits';
-import Pagination from 'react-instantsearch/src/widgets/Pagination';
-import CurrentRefinements
-  from 'react-instantsearch/src/widgets/CurrentRefinements';
-import Stats from 'react-instantsearch/src/widgets/Stats';
+import { createConnector } from 'react-instantsearch';
+import {
+  Hits,
+  Pagination,
+  CurrentRefinements,
+  Stats,
+} from 'react-instantsearch/dom';
 
 import Hit from '../Hit';
 import { isEmpty } from '../util';

--- a/js/src/lib/Search/SearchBox.js
+++ b/js/src/lib/Search/SearchBox.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import SearchBox from 'react-instantsearch/src/widgets/SearchBox';
+import { SearchBox } from 'react-instantsearch/dom';
 
 class WrappedSearchBox extends Component {
   constructor(props) {

--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -1,15 +1,7 @@
 import React from 'react';
 import qs from 'qs';
-import Configure from 'react-instantsearch/src/widgets/Configure';
-
-import createInstantSearch
-  from 'react-instantsearch/src/core/createInstantSearch';
+import { Configure, InstantSearch } from 'react-instantsearch/dom';
 import algoliasearch from 'algoliasearch';
-
-const InstantSearch = createInstantSearch(algoliasearch, {
-  Root: 'div',
-  props: { className: 'ais-InstantSearch__root' },
-});
 
 import SearchBox from './SearchBox';
 import Results from './Results';

--- a/js/src/lib/util.js
+++ b/js/src/lib/util.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import fetch from 'unfetch';
 import highlightTags from 'react-instantsearch/src/core/highlightTags';
-import connectToggle from 'react-instantsearch/src/connectors/connectToggle';
+import { connectToggle } from 'react-instantsearch/connectors';
 
 export const isEmpty = item => typeof item === 'undefined' || item.length < 1;
 
@@ -57,48 +57,46 @@ export function formatKeywords(
         return k2.matchedWords.length - k1.matchedWords.length;
       }
       if (k1.matchedWords.join('').length !== k2.matchedWords.join('').length) {
-        return k2.matchedWords.join('').length -
-          k1.matchedWords.join('').length;
+        return (
+          k2.matchedWords.join('').length - k1.matchedWords.join('').length
+        );
       }
       return 0;
     })
     .slice(0, maxKeywords)
-    .map(({
-      value: highlightedKeyword,
-      originalValue: keyword,
-    }, keywordIndex) => {
-      const highlighted = parseHighlightedAttribute({
-        highlightedValue: highlightedKeyword,
-      });
-      const content = highlighted.map((v, i) => {
-        const key = `split-${i}-${v.value}`;
-        if (!v.isHighlighted) {
+    .map(
+      ({ value: highlightedKeyword, originalValue: keyword }, keywordIndex) => {
+        const highlighted = parseHighlightedAttribute({
+          highlightedValue: highlightedKeyword,
+        });
+        const content = highlighted.map((v, i) => {
+          const key = `split-${i}-${v.value}`;
+          if (!v.isHighlighted) {
+            return (
+              <span key={key} className="ais-Highlight__nonHighlighted">
+                {v.value}
+              </span>
+            );
+          }
           return (
-            <span key={key} className="ais-Highlight__nonHighlighted">
-              {v.value}
-            </span>
+            <em key={key} className="ais-Highlight__highlighted">{v.value}</em>
           );
-        }
+        });
         return (
-          <em key={key} className="ais-Highlight__highlighted">{v.value}</em>
+          <span className="ais-Hit--keyword" key={`${keyword}${keywordIndex}`}>
+            {content}
+          </span>
         );
-      });
-      return (
-        <span className="ais-Hit--keyword" key={`${keyword}${keywordIndex}`}>
-          {content}
-        </span>
-      );
-    })
+      }
+    )
     .reduce((prev, curr) => [prev, ', ', curr]);
 }
 
-function parseHighlightedAttribute(
-  {
-    preTag = highlightTags.highlightPreTag,
-    postTag = highlightTags.highlightPostTag,
-    highlightedValue,
-  }
-) {
+function parseHighlightedAttribute({
+  preTag = highlightTags.highlightPreTag,
+  postTag = highlightTags.highlightPostTag,
+  highlightedValue,
+}) {
   const splitByPreTag = highlightedValue.split(preTag);
   const firstValue = splitByPreTag.shift();
   const elements = firstValue === ''

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "qs": "^6.4.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-instantsearch": "4.0.0-beta.6",
+    "react-instantsearch": "^4.0.0-beta.6",
     "react-sparklines": "^1.6.0",
     "react-transition-group": "^1.1.2",
     "unfetch": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "qs": "^6.4.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-instantsearch": "^3.2.2-beta0",
+    "react-instantsearch": "4.0.0-beta.6",
     "react-sparklines": "^1.6.0",
     "react-transition-group": "^1.1.2",
     "unfetch": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2623,7 +2623,7 @@ react-dom@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-react-instantsearch@4.0.0-beta.6:
+react-instantsearch@^4.0.0-beta.6:
   version "4.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-4.0.0-beta.6.tgz#bcc651ffa8f7f9d7bc79640d6bb9ca136de3517f"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,11 +1906,7 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-"jquery@1.9.1 - 3":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.0.tgz#3bdbba66e1eee0785532dddadb0e0d2521ca584b"
-
-jquery@^3.2.1:
+"jquery@1.9.1 - 3", jquery@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,7 +2540,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.6:
+prop-types@^15.5.6, prop-types@^15.5.8:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -2623,14 +2623,15 @@ react-dom@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-react-instantsearch@^3.2.2-beta0:
-  version "3.2.2-beta0"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-3.2.2-beta0.tgz#1740631362928432c353276b087be96c7ca39943"
+react-instantsearch@4.0.0-beta.6:
+  version "4.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-4.0.0-beta.6.tgz#bcc651ffa8f7f9d7bc79640d6bb9ca136de3517f"
   dependencies:
     algoliasearch "^3.21.1"
     algoliasearch-helper "2.19.0"
     classnames "^2.2.5"
     lodash "^4.17.4"
+    prop-types "^15.5.8"
 
 react-sparklines@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
React InstantSearch now publishes es2015 modules, and thus the advantage for writing the content of the respective files isn't really there anymore. This makes the code simpler, as well as a few kb's smaller 🚀 