### PR TITLE
Reword warning about npm to remove incorrect implications

### DIFF
--- a/lang/en/docs/_installations/alternatives.md
+++ b/lang/en/docs/_installations/alternatives.md
@@ -11,13 +11,17 @@ recommended to install Yarn via our packages instead.
 
 #### Install via npm
 
-> **Note:** Installation via npm is generally not recommended. npm is 
-> non-deterministic, packages are not signed, and npm does not perform any 
-> integrity checks other than a basic SHA1 hash, which is a security risk 
-> when installing system-wide apps.
+> **Note:** Installation of yarn via npm is generally not recommended.
 >
-> For these reasons, it is highly recommended that you install Yarn through the
-> installation method best suited to your operating system.
+> It is highly recommended that you install Yarn through the installation
+> method best suited to your operating system. This guarantees that you receive
+> the exact dependencies that we expect yarn to have, since installation of
+> dependencies in older versions of npm can be non-deterministic.
+>
+> In addition, when installing system-wide apps, it's ideal to have signed
+> packages, to verify the identity of the packager. Neither npm nor yarn
+> perform any integrity checks other than a basic SHA1 hash, which is a
+> security risk.
 
 You can also install Yarn through the [npm package manager](http://npmjs.org/)
 if you already have it installed. If you already have


### PR DESCRIPTION
The warning about npm is overwhelmingly FUDdy and implies that yarn has better security than npm in their typical usage by mentioning the lack of cryptographic package signing in npm, which is also absent in yarn. also, newer versions of npm are deterministic in their installation (npm 5), and so I added a description of how installation via the OS-specific method solves that problem.

also, just in terms of phrasing, stating the conclusion first and then describing the reasons frames the statement that there's a reason why we're doing this, rather than giving a bunch of statements, and then providing the conclusion, which leaves the reader to unnecessarily construct additional conclusions relating to npm's dependability.