### PR TITLE
feat(size): use algoliasearch/lite

### DIFF
--- a/js/src/lib/Details/index.js
+++ b/js/src/lib/Details/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 
 import Aside from './Aside';
 import FileBrowser from './FileBrowser';

--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import qs from 'qs';
 import { Configure, InstantSearch } from 'react-instantsearch/dom';
-import algoliasearch from 'algoliasearch';
 
 import SearchBox from './SearchBox';
 import Results from './Results';

--- a/js/src/packages.js
+++ b/js/src/packages.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { Owner } from './lib/Hit';
 import { packageLink, Keywords } from './lib/util';
 
@@ -78,5 +78,5 @@ class Featured extends React.Component {
 
 ReactDOM.render(
   <Featured packages={FEATURED} />,
-  document.getElementById('pkg-featured'),
+  document.getElementById('pkg-featured')
 );


### PR DESCRIPTION
vendor.js:

size | before|after
---|---|---
Encoded | 183.54 KB |181.00 KB
Decoded	|753.04 KB| 736.93 KB
Transferred |183.94 KB| 181.32 KB