### PR TITLE
chore(deps): update all js dependencies 2017-05-12

### DIFF
--- a/js/src/lib/Details/Activity.js
+++ b/js/src/lib/Details/Activity.js
@@ -42,9 +42,7 @@ const Activity = ({ data = [], githubRepo }) => {
     <article className="details-side--activity">
       <h1>{window.i18n.detail.activity}</h1>
       <a
-        href={
-          `https://github.com/${encode(githubRepo.user)}/${encode(githubRepo.project)}/graphs/commit-activity`
-        }
+        href={`https://github.com/${encode(githubRepo.user)}/${encode(githubRepo.project)}/graphs/commit-activity`}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/js/src/lib/Details/Copyable.js
+++ b/js/src/lib/Details/Copyable.js
@@ -18,14 +18,11 @@ export default class Copyable extends React.Component {
       this.setState(() => ({
         statusImage: image,
       }));
-      setTimeout(
-        () => {
-          this.setState(() => ({
-            statusImage: images.default,
-          }));
-        },
-        timeout
-      );
+      setTimeout(() => {
+        this.setState(() => ({
+          statusImage: images.default,
+        }));
+      }, timeout);
     };
 
     let range = document.createRange();
@@ -51,7 +48,7 @@ export default class Copyable extends React.Component {
       <div className="copyable">
         <code className="copyable--code">
           {this.props.pre}
-          <span ref={sample => this.installSample = sample}>
+          <span ref={sample => (this.installSample = sample)}>
             {this.props.text}
           </span>
         </code>

--- a/js/src/lib/Details/Header.js
+++ b/js/src/lib/Details/Header.js
@@ -2,18 +2,16 @@ import React from 'react';
 import { License, Owner, Downloads } from '../Hit';
 import { Keywords } from '../util';
 
-const Header = (
-  {
-    name,
-    owner,
-    downloadsLast30Days,
-    humanDownloadsLast30Days,
-    description,
-    license,
-    keywords,
-    version,
-  },
-) => (
+const Header = ({
+  name,
+  owner,
+  downloadsLast30Days,
+  humanDownloadsLast30Days,
+  description,
+  license,
+  keywords,
+  version,
+}) => (
   <header className="details-main--header">
     <h2 className="details-main--title d-inline-block m-2">
       {name}

--- a/js/src/lib/Details/Links.js
+++ b/js/src/lib/Details/Links.js
@@ -27,11 +27,7 @@ const Links = ({ name, homepage, githubRepo, className }) => (
     {githubRepo
       ? <Link
           site="github"
-          url={
-            `https://github.com/${encode(githubRepo.user)}/${encode(
-              githubRepo.project,
-            )}${githubRepo.path}`
-          }
+          url={`https://github.com/${encode(githubRepo.user)}/${encode(githubRepo.project)}${githubRepo.path}`}
           display={`${githubRepo.user}/${githubRepo.project}`}
         />
       : null}

--- a/js/src/lib/Details/ReadMore.js
+++ b/js/src/lib/Details/ReadMore.js
@@ -33,14 +33,12 @@ class ReadMore extends React.Component {
 
     return (
       <div
-        className={
-          `${className} readMore ${collapsed ? 'readMore--collapsed' : ''}`
-        }
+        className={`${className} readMore ${collapsed ? 'readMore--collapsed' : ''}`}
       >
         <div
           className="readMore--content"
           style={{ maxHeight: collapsed ? this.maxHeight : '' }}
-          ref={div => this.content = div}
+          ref={div => (this.content = div)}
         >
           {children}
         </div>

--- a/js/src/lib/Hit/index.js
+++ b/js/src/lib/Hit/index.js
@@ -10,7 +10,7 @@ import {
 } from '../util';
 
 export const License = ({ type }) =>
-  (type ? <span className="ais-Hit--license">{type}</span> : null);
+  type ? <span className="ais-Hit--license">{type}</span> : null;
 
 export const Owner = ({ link, avatar, name }) => (
   <a className="ais-Hit--ownerLink" href={link}>

--- a/js/src/lib/Search/withUrlSync.js
+++ b/js/src/lib/Search/withUrlSync.js
@@ -8,9 +8,9 @@ const searchStateToQueryString = searchState => ({
 });
 
 const searchStateToUrl = searchState =>
-  (searchState
+  searchState
     ? `${window.i18n.url_base}/packages?${qs.stringify(searchStateToQueryString(searchState))}`
-    : '');
+    : '';
 
 const queryStringToSearchState = queryString => {
   const { p, q } = qs.parse(queryString);
@@ -22,55 +22,56 @@ const queryStringToSearchState = queryString => {
 
 const originalPathName = location.pathname;
 
-export default App => class extends Component {
-  constructor() {
-    super();
-    this.state = {
-      searchState: queryStringToSearchState(location.search.slice(1)),
-    };
-    window.addEventListener('popstate', ({ state: searchState }) => {
-      // check we are on a search result
-      if (searchState !== null) {
-        this.setState({ searchState });
-        return;
-      }
+export default App =>
+  class extends Component {
+    constructor() {
+      super();
+      this.state = {
+        searchState: queryStringToSearchState(location.search.slice(1)),
+      };
+      window.addEventListener('popstate', ({ state: searchState }) => {
+        // check we are on a search result
+        if (searchState !== null) {
+          this.setState({ searchState });
+          return;
+        }
 
-      this.setState({ searchState: { query: '' } });
-    });
-  }
-
-  onSearchStateChange = searchState => {
-    clearTimeout(this.debouncedSetState);
-
-    if (searchState.query === '') {
-      if (location.pathname !== originalPathName) {
-        window.history.pushState(
-          null,
-          'Search packages | Yarn',
-          originalPathName
-        );
-      }
-    } else {
-      this.debouncedSetState = setTimeout(() => {
-        window.history.pushState(
-          searchState,
-          'Search packages | Yarn',
-          searchStateToUrl(searchState)
-        );
-      }, updateAfter);
+        this.setState({ searchState: { query: '' } });
+      });
     }
 
-    this.setState({ searchState });
-  };
+    onSearchStateChange = searchState => {
+      clearTimeout(this.debouncedSetState);
 
-  render() {
-    return (
-      <App
-        {...this.props}
-        searchState={this.state.searchState}
-        onSearchStateChange={this.onSearchStateChange.bind(this)}
-        createURL={searchStateToUrl}
-      />
-    );
-  }
-};
+      if (searchState.query === '') {
+        if (location.pathname !== originalPathName) {
+          window.history.pushState(
+            null,
+            'Search packages | Yarn',
+            originalPathName
+          );
+        }
+      } else {
+        this.debouncedSetState = setTimeout(() => {
+          window.history.pushState(
+            searchState,
+            'Search packages | Yarn',
+            searchStateToUrl(searchState)
+          );
+        }, updateAfter);
+      }
+
+      this.setState({ searchState });
+    };
+
+    render() {
+      return (
+        <App
+          {...this.props}
+          searchState={this.state.searchState}
+          onSearchStateChange={this.onSearchStateChange.bind(this)}
+          createURL={searchStateToUrl}
+        />
+      );
+    }
+  };

--- a/js/src/lib/deeplink.js
+++ b/js/src/lib/deeplink.js
@@ -17,7 +17,7 @@ export function handleTabs() {
     history.replaceState(
       history.state,
       document.title,
-      location.pathname + '#' + e.currentTarget.id,
+      location.pathname + '#' + e.currentTarget.id
     );
   });
 }

--- a/js/src/nightly.js
+++ b/js/src/nightly.js
@@ -59,11 +59,11 @@ $('#older-versions .nav-item').on('shown.bs.tab', e => {
       tbody.append(
         $('<tr>').append(
           $('<td>').append(
-            $('<a>').attr('href', build.url).text(build.filename),
+            $('<a>').attr('href', build.url).text(build.filename)
           ),
           $('<td>').text(build.size),
-          $('<td>').text(formatTimeSince(build.date)),
-        ),
+          $('<td>').text(formatTimeSince(build.date))
+        )
       );
     });
     tbody.replaceAll(`#${selectedType}-body`);

--- a/js/src/package.js
+++ b/js/src/package.js
@@ -15,7 +15,7 @@ function languageDropdownAddPackage(pkg) {
   const langMenu = document.getElementById('dropdownNavLanguageMenu');
   const langMenuItems = langMenu.querySelectorAll('.dropdown-item');
 
-  const addPackage = langMenuItem => langMenuItem.href += `/${pkg}`;
+  const addPackage = langMenuItem => (langMenuItem.href += `/${pkg}`);
 
   for (let i = 0; i < langMenuItems.length; i++) {
     addPackage(langMenuItems[i]);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "prettier --write --single-quote --trailing-comma",
+      "prettier --write --single-quote --trailing-comma=es5",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yarn-website",
   "version": "1.0.0",
   "devDependencies": {
-    "algolia-sitemap": "^1.0.1",
+    "algolia-sitemap": "^1.1.0",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
@@ -11,8 +11,8 @@
     "happypack": "^3.0.3",
     "lint-staged": "^3.4.1",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.2.2",
-    "webpack": "^2.4.1",
+    "prettier": "^1.3.1",
+    "webpack": "^2.5.1",
     "webpack-manifest-plugin": "^1.1.0"
   },
   "scripts": {
@@ -42,11 +42,11 @@
     "jquery": "^3.2.1",
     "marked": "^0.3.6",
     "qs": "^6.4.0",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "react-instantsearch": "^4.0.0-beta.6",
     "react-sparklines": "^1.6.0",
-    "react-transition-group": "^1.1.2",
+    "react-transition-group": "^1.1.3",
     "unfetch": "^2.1.2",
     "xss": "^0.3.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,9 +35,9 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-algolia-sitemap@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/algolia-sitemap/-/algolia-sitemap-1.0.1.tgz#8b4b48b910f457618c3d0bb29463130703b6231c"
+algolia-sitemap@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/algolia-sitemap/-/algolia-sitemap-1.1.0.tgz#026faa9fb17e1c3326acd75b4c486e5013b54a42"
   dependencies:
     algoliasearch "^3.22.1"
     xmlbuilder "^8.2.2"
@@ -1416,7 +1416,7 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -1464,9 +1464,9 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-flow-parser@0.43.0:
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.43.0.tgz#e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7"
+flow-parser@0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.45.0.tgz#aa29d4ae27f06aa02817772bba0fcbefef7e62f0"
 
 for-in@^0.1.5:
   version "0.1.6"
@@ -2497,16 +2497,16 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.2.2.tgz#22d17c1132faaaea1f1d4faea31f19f7a1959f3e"
+prettier@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.3.1.tgz#fa0ea84b45ac0ba6de6a1e4cecdcff900d563151"
   dependencies:
     ast-types "0.9.8"
     babel-code-frame "6.22.0"
     babylon "7.0.0-beta.8"
     chalk "1.1.3"
     esutils "2.0.2"
-    flow-parser "0.43.0"
+    flow-parser "0.45.0"
     get-stdin "5.0.1"
     glob "7.1.1"
     jest-validate "19.0.0"
@@ -2540,7 +2540,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.6, prop-types@^15.5.8:
+prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -2615,13 +2615,14 @@ react-addons-shallow-compare@^15.0.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-dom@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
 react-instantsearch@^4.0.0-beta.6:
   version "4.0.0-beta.6"
@@ -2639,22 +2640,23 @@ react-sparklines@^1.6.0:
   dependencies:
     react-addons-shallow-compare "^15.0.2"
 
-react-transition-group@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.1.2.tgz#374cd778070f74b0a658045fc532edfd471ad836"
+react-transition-group@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.1.3.tgz#5e02cf6e44a863314ff3c68a0c826c2d9d70b221"
   dependencies:
     chain-function "^1.0.0"
     dom-helpers "^3.2.0"
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3180,9 +3182,9 @@ webpack-sources@^0.2.3:
     source-list-map "^1.1.1"
     source-map "~0.5.3"
 
-webpack@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.4.1.tgz#15a91dbe34966d8a4b99c7d656efd92a2e5a6f6a"
+webpack@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.5.1.tgz#61742f0cf8af555b87460a9cd8bba2f1e3ee2fce"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"


### PR DESCRIPTION
1. some dependencies without any significant change
2. algolia-sitemap now generates less sitemaps because they are aggregated to 50k links per sitemap (the maximum)
3. react to 15.5.4 -> all dependencies are compatible without warnings
4. prettier -> run it on all files again, so the js diff is only because of that.