### PR TITLE
feat(Deprecation): show if a package is deprecated

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -302,6 +302,7 @@ script:
   npm: npm
   github: GitHub
   homepage: Homepage
+  deprecated: deprecated
 
   detail:
     over_a_year_ago: over a year ago

--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -192,6 +192,18 @@ $ais-muted-color: rgba(black,.5);
     letter-spacing: .2px;
   }
 
+  &--deprecated {
+    font-size: .75rem;
+    text-transform: uppercase;
+    background-color: #ccc;
+    border: solid 1px #ccc;
+    color: white;
+    padding: 2px 4px;
+    border-radius: 4px;
+    margin-right: 8px;
+    letter-spacing: .2px;
+  }
+
   &--version {
     font-size: .825rem;
     color: $ais-muted-color;

--- a/js/src/lib/Details/Header.js
+++ b/js/src/lib/Details/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { License, Owner, Downloads } from '../Hit';
+import { License, Deprecated, Owner, Downloads } from '../Hit';
 import { Keywords } from '../util';
 
 const Header = ({
@@ -9,6 +9,7 @@ const Header = ({
   humanDownloadsLast30Days,
   description,
   license,
+  deprecated,
   keywords,
   version,
 }) => (
@@ -23,6 +24,7 @@ const Header = ({
         humanDownloads={humanDownloadsLast30Days}
       />
       <License type={license} />
+      <Deprecated deprecated={deprecated} />
       <span className="ais-Hit--version">{version}</span>
     </div>
     <p className="m-2 lead">{description}</p>

--- a/js/src/lib/Details/index.js
+++ b/js/src/lib/Details/index.js
@@ -146,6 +146,7 @@ class Details extends Component {
             humanDownloadsLast30Days={this.state.humanDownloadsLast30Days}
             description={this.state.description}
             license={this.state.license}
+            deprecated={this.state.deprecated}
             keywords={this.state.keywords}
             version={this.state.version}
           />

--- a/js/src/lib/Hit/index.js
+++ b/js/src/lib/Hit/index.js
@@ -12,6 +12,11 @@ import {
 export const License = ({ type }) =>
   type ? <span className="ais-Hit--license">{type}</span> : null;
 
+export const Deprecated = ({ deprecated }) =>
+  deprecated
+    ? <span className="ais-Hit--deprecated">{window.i18n.deprecated}</span>
+    : null;
+
 export const Owner = ({ link, avatar, name }) => (
   <a className="ais-Hit--ownerLink" href={link}>
     <img
@@ -76,6 +81,7 @@ const Hit = ({ hit }) => (
       humanDownloads={hit.humanDownloadsLast30Days}
     />
     <License type={hit.license} />
+    <Deprecated deprecated={hit.deprecated} />
     <span className="ais-Hit--version">{hit.version}</span>
     <p className="ais-Hit--description">
       <Highlight attributeName="description" hit={hit} />

--- a/js/src/lib/Search/SearchBox.js
+++ b/js/src/lib/Search/SearchBox.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { SearchBox } from 'react-instantsearch/dom';
 
 class WrappedSearchBox extends Component {

--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -27,17 +27,18 @@ const Search = props => (
       }
       facets={['keywords']}
       attributesToRetrieve={[
-        'name',
-        'downloadsLast30Days',
-        'humanDownloadsLast30Days',
-        'license',
-        'version',
+        'deprecated',
         'description',
-        'modified',
-        'keywords',
-        'homepage',
+        'downloadsLast30Days',
         'githubRepo',
+        'homepage',
+        'humanDownloadsLast30Days',
+        'keywords',
+        'license',
+        'modified',
+        'name',
         'owner',
+        'version',
       ]}
     />
     <SearchBox

--- a/js/src/packages.js
+++ b/js/src/packages.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import algoliasearch from 'algoliasearch/lite';
 import { Owner } from './lib/Hit';

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "docsearch.js": "^2.3.3",
     "jquery": "^3.2.1",
     "marked": "^0.3.6",
+    "prop-types": "^15.5.10",
     "qs": "^6.4.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2118,7 +2118,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2539,6 +2539,13 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.8"


### PR DESCRIPTION
It's a badge just like the License one, but inversed

(also included in this PR is moving from React.PropTypes -> PropTypes, apparently I didn't get that message when upgrading the deps yesterday)

An example is http://deploy-preview-493--yarnpkg.netlify.com/en/packages?q=pixi-extra-filters-waiting-for-publication

Screenshots: 

Search result:

<img width="1176" alt="screen shot 2017-05-13 at 16 32 22" src="https://cloud.githubusercontent.com/assets/6270048/26026397/5319c864-37fa-11e7-80a6-dcf3beb693c9.png">

Detail page:

<img width="717" alt="screen shot 2017-05-13 at 16 32 09" src="https://cloud.githubusercontent.com/assets/6270048/26026385/30d71e28-37fa-11e7-89ea-23a4aae78c5e.png">
