### PR TITLE
feat(files): show size in file listing

### DIFF
--- a/_sass/_details.scss
+++ b/_sass/_details.scss
@@ -132,6 +132,20 @@
       & & {
         padding-left: 1.5em;
       }
+
+      li {
+        padding: .2em;
+
+        &:hover {
+          background-color: #eceeef;
+          border-radius: .2em;
+
+          ul {
+            background-color: white;
+            border-radius: .2em;
+          }
+        }
+      }
     }
 
     // File and directory names

--- a/css/main.scss
+++ b/css/main.scss
@@ -48,9 +48,15 @@ $npm-red: #C12127;
 @import "_copyable.scss";
 
 // should come from bootstrap but it doesn't
-.flex-items-between {
+.justify-items-between {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.align-items-baseline {
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
 }

--- a/js/src/lib/Details/Activity.js
+++ b/js/src/lib/Details/Activity.js
@@ -55,7 +55,7 @@ const Activity = ({ data = [], githubRepo }) => {
         </Sparklines>
       </a>
       <dl>
-        <div className="d-flex flex-items-between w-100">
+        <div className="d-flex justify-items-between w-100">
           <img src="/assets/detail/ico-commits.svg" alt="" />
           <dt>{window.i18n.detail.commits_last_three_months}</dt>
           <span className="dotted flex-grow" />
@@ -63,7 +63,7 @@ const Activity = ({ data = [], githubRepo }) => {
             {countCommitsLastThreeMonths({ weeklyData: data })}
           </dd>
         </div>
-        <div className="d-flex flex-items-between w-100">
+        <div className="d-flex justify-items-between w-100">
           <img src="/assets/detail/ico-commits-last.svg" alt="" />
           <dt>{window.i18n.detail.last_commit}</dt>
           <span className="dotted flex-grow" />

--- a/js/src/lib/Details/FileBrowser.js
+++ b/js/src/lib/Details/FileBrowser.js
@@ -3,6 +3,8 @@ import React from 'react';
 
 import fetch from 'unfetch';
 
+import bytes from 'bytes';
+
 const SORT_ORDER = { directory: 1, file: 2 };
 
 function getBasename(path) {
@@ -169,6 +171,7 @@ class Directory extends React.PureComponent {
                 file={file}
                 key={file.path}
                 url={this.props.baseURL + file.path.substr(1)}
+                size={file.size}
               />
             );
           }
@@ -183,10 +186,14 @@ class Directory extends React.PureComponent {
   };
 }
 
-const File = ({ file, url }) => (
-  <li key={file.path}>
+const File = ({ file, url, size }) => (
+  <li
+    key={file.path}
+    className="d-flex justify-items-between align-items-baseline"
+  >
     <a className="details-files__filename" href={url} target="_blank">
       {getBasename(file.path)}
     </a>
+    <small>{bytes(size)}</small>
   </li>
 );

--- a/js/src/lib/Details/Popularity.js
+++ b/js/src/lib/Details/Popularity.js
@@ -12,7 +12,7 @@ const Popularity = ({
     <h1>{window.i18n.detail.popularity}</h1>
     <dl>
       {stargazers > 0 &&
-        <div className="d-flex flex-items-between w-100">
+        <div className="d-flex justify-items-between w-100">
           <img src="/assets/detail/ico-stargazers.svg" alt="" />
           <dt>{window.i18n.detail.github_stargazers}</dt>
           <span className="dotted flex-grow" />
@@ -20,7 +20,7 @@ const Popularity = ({
         </div>}
       {downloads > 0 &&
         humanDownloads &&
-        <div className="d-flex flex-items-between w-100">
+        <div className="d-flex justify-items-between w-100">
           <img src="/assets/detail/ico-downloads.svg" alt="" />
           <dt>{window.i18n.detail.downloads_last_30_days}</dt>
           <span className="dotted flex-grow" />
@@ -29,7 +29,7 @@ const Popularity = ({
           </dd>
         </div>}
       {dependents > 0 &&
-        <div className="d-flex flex-items-between w-100">
+        <div className="d-flex justify-items-between w-100">
           <img src="/assets/detail/ico-dependents.svg" alt="" />
           <dt>{window.i18n.detail.dependents}</dt>
           <span className="dotted flex-grow" />

--- a/js/src/lib/Details/Usage.js
+++ b/js/src/lib/Details/Usage.js
@@ -5,7 +5,7 @@ const Deps = ({ dependencies, text, id }) => {
   if (dependencies) {
     const dependencyNames = Object.keys(dependencies);
     return (
-      <div className="d-flex flex-items-between w-100">
+      <div className="d-flex justify-items-between w-100">
         <img src={`/assets/detail/ico-${id}.svg`} alt="" />
         <dt>
           {dependencyNames.length > 0
@@ -47,7 +47,7 @@ const Usage = ({
         id="devdependencies"
       />
       {packageJSONLink &&
-        <div className="d-flex flex-items-between w-100">
+        <div className="d-flex justify-items-between w-100">
           <img src="/assets/detail/ico-package-json.svg" alt="" />
           <dt>{window.i18n.detail.packages}</dt>
           <span className="dotted flex-grow" />

--- a/js/src/lib/Details/Versions.js
+++ b/js/src/lib/Details/Versions.js
@@ -30,7 +30,7 @@ export default class Versions extends Component {
         <h1>{window.i18n.detail.versions}</h1>
         <dl>
           {versionsToShow.map(version => (
-            <div key={version} className="d-flex flex-items-between w-100">
+            <div key={version} className="d-flex justify-items-between w-100">
               <dt>
                 {new Date(versions[version]).toLocaleDateString(
                   window.i18n.active_language,

--- a/lang/en/package.html
+++ b/lang/en/package.html
@@ -1,11 +1,11 @@
----
-layout: pages/detail
+--- 
+layout: pages/detail 
 scripts:
-- "/js/build/package.js"
+  - "/js/build/package.js" 
 ---
-{% comment %}
-this is the default package view to make the load percieve smoother,
-for the implementation, look at /js/lib/Details/index.js etc.
+{% comment %} 
+this is the default package view to make the load percieve smoother, 
+for the implementation, look at /js/lib/Details/index.js etc. 
 {% endcomment %}
 <div id="pkg-detail">
   <div data-reactroot="" class="details row">
@@ -52,15 +52,15 @@ for the implementation, look at /js/lib/Details/index.js etc.
       <article class="details-side--usage">
         <h1>Usage</h1>
         <dl>
-          <div class="d-flex flex-items-between w-100"><img src="/assets/detail/ico-dependencies.svg" alt="">
+          <div class="d-flex justify-items-between w-100"><img src="/assets/detail/ico-dependencies.svg" alt="">
             <dt>Dependencies</dt><span class="dotted flex-grow"></span>
             <dd>0</dd>
           </div>
-          <div class="d-flex flex-items-between w-100"><img src="/assets/detail/ico-devdependencies.svg" alt="">
+          <div class="d-flex justify-items-between w-100"><img src="/assets/detail/ico-devdependencies.svg" alt="">
             <dt>DevDependencies</dt><span class="dotted flex-grow"></span>
             <dd>0</dd>
           </div>
-          <div class="d-flex flex-items-between w-100"><img src="/assets/detail/ico-package-json.svg" alt="">
+          <div class="d-flex justify-items-between w-100"><img src="/assets/detail/ico-package-json.svg" alt="">
             <dt>Packages</dt><span class="dotted flex-grow"></span>
             <dd><a href="https://github.com///tree/master/package.json">see package.json</a></dd>
           </div>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "algoliasearch": "^3.22.1",
     "bootstrap": "4.0.0-alpha.5",
+    "bytes": "^2.5.0",
     "date-fns": "^1.28.4",
     "docsearch.js": "^2.3.3",
     "jquery": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,6 +971,10 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bytes@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -2540,18 +2544,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10:
+prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
-
-prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
-  dependencies:
-    fbjs "^0.8.9"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
For this to make sense I added a background on hovering a certain listing, since they might sometimes be pretty wide.

I also added another utility class that should be in bootstrap, but isn't for some reason, but it's to align on the baseline.

I used the small [bytes](https://yarnpkg.com/en/package/bytes) utility to show the sizes in kB etc.

Screenshot:

<img width="753" alt="screen shot 2017-05-14 at 17 30 50" src="https://cloud.githubusercontent.com/assets/6270048/26035414/eb55ddb2-38cb-11e7-9bfe-4acad85da452.png">

[preview](https://deploy-preview-494--yarnpkg.netlify.com/en/package/algoliasearch-helper)
