### PR TITLE
Added missing doc: production=false overrides NODE_ENV

### DIFF
--- a/lang/en/docs/cli/install.md
+++ b/lang/en/docs/cli/install.md
@@ -66,13 +66,11 @@ Specifies an alternate location for the `node_modules` directory, instead of the
 
 Don't read or generate a `yarn.lock` lockfile.
 
-##### `yarn install --production` <a class="toc" id="toc-yarn-install-production" href="#toc-yarn-install-production"></a>
+##### `yarn install --production[=true|false]` <a class="toc" id="toc-yarn-install-production" href="#toc-yarn-install-production"></a>
 
-Using the `--production` flag, or when the `NODE_ENV` environment variable is
-set to `production`, Yarn will not install any package listed in
-`devDependencies`.
+Yarn will not install any package listed in `devDependencies` if the `NODE_ENV` environment variable is set to `production`. Use this flag to instruct Yarn to ignore `NODE_ENV` and take its production-or-not status from this flag instead.
 
-> **Note:** `--prod` is also an alias of `--production`.
+> **Notes:** `--production` is the same as `--production=true`. `--prod` is an alias of `--production`.
 
 ##### `yarn install --pure-lockfile` <a class="toc" id="toc-yarn-install-pure-lockfile" href="#toc-yarn-install-pure-lockfile"></a>
 


### PR DESCRIPTION
There was no doc for yarnpkg/yarn#2223.

Note: I don't know about the significance of `NODE_ENV` and if it's used to decided anything other than installing `devDependencies` or not. This PR only speaks of `devDependencies` (as was the case before it).