### PR TITLE
Reword npm installation warning to avoid wrong implications

### DIFF
--- a/lang/en/docs/_installations/alternatives.md
+++ b/lang/en/docs/_installations/alternatives.md
@@ -12,7 +12,7 @@ recommended to install Yarn via our packages instead.
 #### Install via npm
 
 > **Note:** Installation of Yarn via npm is generally not recommended.
-> Installing Yarn with npm is non-deterministic, the package is not signed,
+> When installing Yarn with Node-based package managers, the package is not signed,
 > and the only integrity check performed is a basic SHA1 hash, which is a
 > security risk when installing system-wide apps.
 >


### PR DESCRIPTION
A version of this was originally submitted in https://github.com/yarnpkg/website/pull/484 and closed in favor of https://github.com/yarnpkg/website/issues/485 which got merged.

I think we can further improve it to make it clear this is not a dig at npm, and that the problem is common to any mainstream Node-based package managers. I kept the title as `Install via npm` and kept the mention of npm in the first sentence because that's realistically what people are going to do, but I hope this makes it clearer that the issue is not in npm itself, but rather that today’s Node package managers don’t give these guarantees (Yarn being no exception).