### PR TITLE
feat(deprecation): show deprecated message

### DIFF
--- a/js/src/lib/Hit/index.js
+++ b/js/src/lib/Hit/index.js
@@ -15,7 +15,9 @@ export const License = ({ type }) =>
 
 export const Deprecated = ({ deprecated }) =>
   deprecated
-    ? <span className="ais-Hit--deprecated">{window.i18n.deprecated}</span>
+    ? <span className="ais-Hit--deprecated" title={deprecated}>
+        {window.i18n.deprecated}
+      </span>
     : null;
 
 export const Owner = ({ link, avatar, name }) => (


### PR DESCRIPTION
The `deprecated` value in the index is either `false` or a string. This adds that string as a `title` to that badge. In the future this message would be visible more clearly, but I couldn't think of a good UI to put it, so this is a nice inbetween state where you can already read the message if you want

related: https://github.com/algolia/yarnpkg-website/issues/20#issuecomment-304726188

cc @vvo