### PR TITLE
feat(deprecation): make more visible

### DIFF
--- a/js/src/lib/Details/Header.js
+++ b/js/src/lib/Details/Header.js
@@ -2,6 +2,20 @@ import React from 'react';
 import { License, Deprecated, Owner, Downloads } from '../Hit';
 import { Keywords, safeMarkdown } from '../util';
 
+const Description = ({ description, deprecated }) => (
+  <div>
+    {deprecated
+      ? <p className="m-2">
+          <strong dangerouslySetInnerHTML={safeMarkdown(deprecated)} />
+        </p>
+      : null}
+    <p
+      className="m-2 lead"
+      dangerouslySetInnerHTML={safeMarkdown(description)}
+    />
+  </div>
+);
+
 const Header = ({
   name,
   owner,
@@ -27,10 +41,7 @@ const Header = ({
       <Deprecated deprecated={deprecated} />
       <span className="ais-Hit--version">{version}</span>
     </div>
-    <p
-      className="m-2 lead"
-      dangerouslySetInnerHTML={safeMarkdown(description)}
-    />
+    <Description description={description} deprecated={deprecated} />
     <Keywords keywords={keywords} />
   </header>
 );

--- a/js/src/lib/Hit/index.js
+++ b/js/src/lib/Hit/index.js
@@ -87,7 +87,9 @@ const Hit = ({ hit }) => (
     <Deprecated deprecated={hit.deprecated} />
     <span className="ais-Hit--version">{hit.version}</span>
     <p className="ais-Hit--description">
-      <HighlightedMarkdown attributeName="description" hit={hit} />
+      {hit.deprecated
+        ? hit.deprecated
+        : <HighlightedMarkdown attributeName="description" hit={hit} />}
     </p>
     <Owner {...hit.owner} />
     <span className="ais-Hit--lastUpdate" title="last updated">


### PR DESCRIPTION
On the search page the deprecation message will show instead of the description

On the detail page the deprecation message is visible in bold before the description

cc @vvo

before|after
---|---
<img width="642" alt="screen shot 2017-05-29 at 22 29 04" src="https://cloud.githubusercontent.com/assets/6270048/26681242/bba92c6c-46dc-11e7-881a-6b096dd9fc87.png"> | <img width="709" alt="screen shot 2017-06-01 at 15 04 04" src="https://cloud.githubusercontent.com/assets/6270048/26681244/bbdad636-46dc-11e7-8563-34308b455bd7.png">
<img width="1123" alt="screen shot 2017-06-01 at 15 09 17" src="https://cloud.githubusercontent.com/assets/6270048/26681245/bc0b7048-46dc-11e7-98e0-3d43b605c5ef.png"> | <img width="1123" alt="screen shot 2017-06-01 at 15 08 50" src="https://cloud.githubusercontent.com/assets/6270048/26681243/bbcd44b2-46dc-11e7-80aa-5e27645c6492.png"> 