### PR TITLE
feat(i18n): add translation key for stats

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -307,6 +307,7 @@ script:
   github: GitHub
   homepage: Homepage
   deprecated: deprecated
+  result_stats: 'found {number_packages} packages in {time_search}ms'
 
   detail:
     over_a_year_ago: over a year ago

--- a/js/src/lib/Search/Results.js
+++ b/js/src/lib/Search/Results.js
@@ -16,7 +16,17 @@ const ResultsFound = ({ pagination }) => (
   <div className="container">
     <div className="mx-3">
       <CurrentRefinements />
-      <Stats />
+      <Stats
+        translations={{
+          stats: (num, time) =>
+            window.i18n.result_stats
+              .replace(
+                '{number_packages}',
+                num.toLocaleString(window.i18n.active_language)
+              )
+              .replace('{time_search}', time),
+        }}
+      />
     </div>
     <Hits hitComponent={Hit} />
     <div className="d-flex">


### PR DESCRIPTION
before|after
---|---
<img width="266" alt="screen shot 2017-06-01 at 16 02 59" src="https://cloud.githubusercontent.com/assets/6270048/26683427/0d705f0a-46e4-11e7-83e1-e1212a01fc56.png">|<img width="300" alt="screen shot 2017-06-01 at 15 52 25" src="https://cloud.githubusercontent.com/assets/6270048/26683426/0d0964c6-46e4-11e7-8101-7ed444e99fa9.png">


the number will use the locale of the current url, as in other places