### PR TITLE
feat(i18n): add translation key for "Read more"

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -212,6 +212,8 @@ translations: Translations
 release_process: Release Process
 governance: Governance
 
+read_more: Read more
+
 users: Yarn Users
 compare: Compare Yarn Performance
 blog: Blog

--- a/_layouts/pages/docs.html
+++ b/_layouts/pages/docs.html
@@ -24,7 +24,7 @@ scripts:
         <h4 class="card-title">{{i18n[guide.title]}}</h4>
         <p class="card-text text-muted">
           {{i18n[guide.description]}}
-          <span class="float-right text-primary">Read more</span>
+          <span class="float-right text-primary">{{i18n.read_more}}</span>
         </p>
       </div>
     </a>


### PR DESCRIPTION
Allows to translate "Read more" in Crowdin for the page that is [here](https://yarnpkg.com/fr/docs) :

![yarn](https://user-images.githubusercontent.com/163352/26868940-f61dae8a-4b6a-11e7-83e1-9a02740f770a.png)


