### PR TITLE
Fix available global command list

### DIFF
--- a/lang/en/docs/cli/global.md
+++ b/lang/en/docs/cli/global.md
@@ -10,7 +10,7 @@ layout: guide
 
 ##### `yarn global <add/bin/ls/remove/upgrade> [--prefix]` <a class="toc" id="toc-yarn-global" href="#toc-yarn-global"></a>
 
-`yarn global` is a prefix used for a number of commands like `add`, `bin`, `ls` and `remove`. They behave identically to their normal versions except that they use a global directory to store packages. The `global` command makes binaries available to use on your operating system.
+`yarn global` is a prefix used for a number of commands like `add`, `bin`, `list` and `remove`. They behave identically to their normal versions except that they use a global directory to store packages. The `global` command makes binaries available to use on your operating system.
 
 *Note: Unlike the `--global` flag in npm, `global` is a command which must immediately follow `yarn`. Entering `yarn add global package-name` will add the packages named `global` and `package-name` locally instead of adding `package-name` globally.*
 


### PR DESCRIPTION
The commands available globally at the first paragraph are: `add`, `bin`, `ls` and `remove`.
But `ls` should be `list`.