### PR TITLE
fix(markdown): rewrite urls to GitHub relative ones in raw html

### DIFF
--- a/js/src/lib/Details/Markdown.js
+++ b/js/src/lib/Details/Markdown.js
@@ -31,6 +31,32 @@ const renderAndEscapeMarkdown = ({ source, githubRepo, gitHead }) => {
         path,
       })}" title="${title}">${text}</a>`;
     };
+
+    renderer.html = function(html) {
+      return html
+        .replace(
+          /(<img src=")([^"]*)/g,
+          (match, pre, href) =>
+            `${pre}${prefixURL(href, {
+              base: 'https://raw.githubusercontent.com',
+              user,
+              project,
+              head: gitHead ? gitHead : 'master',
+              path,
+            })}`
+        )
+        .replace(
+          /(<a href=")([^"]*)/g,
+          (match, pre, href) =>
+            `${pre}${prefixURL(href, {
+              base: 'https://github.com',
+              user,
+              project,
+              head: gitHead ? `tree/${gitHead}` : 'tree/master',
+              path,
+            })}`
+        );
+    };
   }
 
   const html = marked(source, { renderer });

--- a/js/src/lib/Details/Markdown.js
+++ b/js/src/lib/Details/Markdown.js
@@ -33,15 +33,11 @@ const renderAndEscapeMarkdown = ({ source, githubRepo, gitHead }) => {
       `<a href="${prefix(href, GITHUB.main)}" title="${title}">${text}</a>`;
 
     renderer.html = function(html) {
-      return html
-        .replace(
-          /src="([^"]*)/g,
-          (match, href) => `src="${prefix(href, GITHUB.raw)}`
-        )
-        .replace(
-          /href="([^"]*)/g,
-          (match, href) => `href="${prefix(href, GITHUB.main)}`
-        );
+      return html.replace(
+        /(src|href)="([^"]*)/g,
+        (match, type, href) =>
+          `${type}="${prefix(href, type === 'href' ? GITHUB.main : GITHUB.raw)}`
+      );
     };
   }
 


### PR DESCRIPTION
Raw html doesn't get lexed and parsed by Marked, and thus the custom rules for images and links don't get applied. To fix that, the same rewriting needs to happen on raw html too.

I might have a little duplicate code here, I wonder how to make it simpler, but I'm pretty tired now and this works at least.

closes prettier/prettier#2186
closes #531

note: might want to switch to something that works nicer with React than marked, and has the same rewriting and GFM capabilities, but not worth the effort yet