### PR TITLE
Show system status message on website when available

### DIFF
--- a/_sass/_heros.scss
+++ b/_sass/_heros.scss
@@ -13,6 +13,11 @@
     color: white;
     text-decoration: underline;
   }
+
+  .alert {
+    // Pull alert back into the margin on top of the hero, when visible.
+    margin-top: -1.5rem;
+  }
 }
 
 .hero::after {
@@ -119,6 +124,10 @@
   .hero {
     margin: 0 0 3rem 0;
     padding: 4rem 0;
+
+    .alert {
+      margin-top: -3rem;
+    }
   }
 
   .hero-title {
@@ -165,6 +174,10 @@
 
     &.small {
       padding: 2rem 0;
+    }
+
+    .alert {
+      margin-top: -4rem;
     }
   }
 

--- a/js/src/common.js
+++ b/js/src/common.js
@@ -6,6 +6,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { fillLanguageDropdown } from './lib/production';
 import Search from './lib/Search';
+import { checkServiceStatus } from './lib/serviceStatus';
+
+checkServiceStatus();
 
 ReactDOM.render(<Search />, document.getElementById('search'));
 

--- a/js/src/lib/serviceStatus.js
+++ b/js/src/lib/serviceStatus.js
@@ -1,0 +1,44 @@
+export function checkServiceStatus() {
+  const xhr = new XMLHttpRequest();
+  xhr.open('get', 'https://status.yarnpkg.com/api/v1/status', true);
+  xhr.onload = () => {
+    try {
+      const data = JSON.parse(xhr.responseText).data;
+      if (data.status !== 'success') {
+        showStatusMessage(data.message);
+      }
+    } catch (ex) {
+      console.warn('Could not fetch service status: ' + ex.message);
+    }
+  };
+  xhr.send();
+}
+
+export function showStatusMessage(message) {
+  const alertEl = document.createElement('div');
+  alertEl.className = 'alert alert-danger alert-dismissible fade hide';
+  alertEl.setAttribute('role', 'alert');
+  alertEl.innerHTML = `
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <strong>Status:</strong>
+    <span class="system-status"></span>.
+    <a href="https://status.yarnpkg.com/" class="alert-link">Read More &rarr;</a>
+    </div>`;
+
+  // Set text using textContent so it's not vulnerable to XSS
+  const messageEl = alertEl.querySelector('.system-status');
+  messageEl.textContent = message;
+
+  // Insert into the hero, above the title
+  let containerEl = document.querySelector('.hero > .container');
+  if (!containerEl) {
+    containerEl = document.body;
+  }
+  containerEl.insertBefore(alertEl, containerEl.firstChild);
+
+  // Fade the alert in
+  window.setTimeout(() => alertEl.classList.remove('hide'), 0);
+  window.setTimeout(() => alertEl.classList.add('show'), 20);
+}


### PR DESCRIPTION
I set up a status page at https://status.yarnpkg.com/ as suggested in #416. When the status is "bad" (ie. something is broken), we should show a banner on the site:

![](http://ss.dan.cx/2017/06/chrome_21-12.05.48.png)

![](http://ss.dan.cx/2017/06/chrome_21-12.06.35.png)

Closes #534