### PR TITLE
Update upgrade-interactive to use correct semver

### DIFF
--- a/lang/en/docs/cli/upgrade-interactive.md
+++ b/lang/en/docs/cli/upgrade-interactive.md
@@ -11,11 +11,11 @@ additional_reading_tags: ["cli-add", "cli-tag", "dependencies-versions", "cli-up
 
 ##### `yarn upgrade-interactive` <a class="toc" id="toc-yarn-upgrade-interactive" href="#toc-yarn-upgrade-interactive"></a>
 
-The default mode installs and updates the packages to use major versions.
+The default mode installs and updates the packages to use minor versions.
 
 ##### `yarn upgrade-interactive [--tilde/-T]` <a class="toc" id="toc-yarn-upgrade-interactive-t" href="#toc-yarn-upgrade-interactive-t"></a>
 
-Using `--tilde` or `-T` installs and updates them as minor versions.
+Using `--tilde` or `-T` installs and updates them as patch versions.
 
 ##### `yarn upgrade-interactive [--exact/-E]` <a class="toc" id="toc-yarn-upgrade-interactive-e" href="#toc-yarn-upgrade-interactive-e"></a>
 


### PR DESCRIPTION
Incorrect help option was being used [here](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/upgrade-interactive.js#L17). The default mode uses minor versions, and tilde should refer to patch (separate PR for help option here: https://github.com/yarnpkg/yarn/pull/3690)