### PR TITLE
feat(build): use babel react transforms

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,23 @@
 {
   "presets": [
-    ["es2015", { "modules": false }],
     // webpack understands the native import syntax, and uses it for tree shaking
-
-    "stage-2",
+    [
+      "es2015",
+      {
+        "modules": false
+      }
+    ],
     // Specifies what level of language features to activate.
     // Stage 2 is "draft", 4 is finished, 0 is strawman.
     // See https://tc39.github.io/process-document/
-
-    "react"
+    "stage-2",
     // Transpile React components to JavaScript
+    "react"
   ],
+  "plugins": [
+    // Treat React JSX elements as value types and hoist them to the highest scope
+    "transform-react-constant-elements",
+    // Turn JSX elements into exploded React objects
+    "transform-react-inline-elements"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "algolia-sitemap": "^2.0.6",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.0",
+    "babel-plugin-transform-react-constant-elements": "^6.23.0",
+    "babel-plugin-transform-react-inline-elements": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,9 +666,21 @@ babel-plugin-transform-object-rest-spread@^6.22.0:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-constant-elements@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz#2f119bf4d2cdd45eb9baaae574053c604f6147dd"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-react-display-name@^6.23.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-inline-elements@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-inline-elements/-/babel-plugin-transform-react-inline-elements-6.22.0.tgz#6687211a32b49a52f22c573a2b5504a25ef17c53"
   dependencies:
     babel-runtime "^6.22.0"
 


### PR DESCRIPTION
* transform-react-constant-elements for extracting constant JSX
* transform-react-inline-elements for inlining JSX as a React object

I added these as a test, you can see the result at <https://feat-react-babel-transforms--yarnpkg.netlify.com/en/>

I didn’t see a significant improvement with this though, so I’m not sure if it’s really needed here. 