### PR TITLE
fix(css): only include docsearch style on needed page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,6 @@
       <link rel="stylesheet" href="{{stylesheet}}" />
     {% endfor %}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/fontawesome/4.7.0/css/font-awesome.min.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css">
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}">
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?unknown=polyfill"></script>
   </head>

--- a/lang/en/docs/index.md
+++ b/lang/en/docs/index.md
@@ -1,4 +1,5 @@
 ---
 id: docs_index
 layout: pages/docs
+stylesheets: https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css
 ---


### PR DESCRIPTION
The only page where docsearch (currently) is visible is on /lang/docs/, not any other page. So in the time that it isn't visible in other places, it should only be included there

<https://fix-docsearch-style-when-needed--yarnpkg.netlify.com/en/docs> with the css

<https://fix-docsearch-style-when-needed--yarnpkg.netlify.com/> without the css 

This is a 10kb (pre-gzip) win on pages that aren’t /en/docs