### PR TITLE
feat(Detail): give a special page when the package doesn't exist

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -347,3 +347,8 @@ script:
     versions: Versions
     display_all: Display all
     hide: Hide
+
+    not_found: 
+      whoa: Whoa, {package_name} does not exist yet
+      yours: But that means it is now yours!
+      make: Make your package

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,19 +3,19 @@
 ---
 @charset "utf-8";
 
-$yarn-blue-light:   #BADAE8;
-$yarn-blue:         #2C8EBB;
-$yarn-blue-dark:    #2188b6;
-$yarn-blue-darker:  #1b7eab;
+$yarn-blue-light: #BADAE8;
+$yarn-blue: #2C8EBB;
+$yarn-blue-dark: #2188b6;
+$yarn-blue-darker: #1b7eab;
 $yarn-blue-darkest: #1476A2;
 
-$text-muted:    #52585e;
+$text-muted: #52585e;
 $text-muted-er: #6d767d;
 
-$navbar-light-color:          rgba(0,0,0,.6);
-$navbar-light-hover-color:    rgba(0,0,0,.7);
-$navbar-light-active-color:   rgba(0,0,0,.8);
-$navbar-light-disabled-color: rgba(0,0,0,.3);
+$navbar-light-color: rgba(0, 0, 0, .6);
+$navbar-light-hover-color: rgba(0, 0, 0, .7);
+$navbar-light-active-color: rgba(0, 0, 0, .8);
+$navbar-light-disabled-color: rgba(0, 0, 0, .3);
 
 $brand-primary: $yarn-blue;
 $progress-bar-color: $brand-primary;
@@ -59,4 +59,15 @@ $npm-red: #C12127;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
   align-items: baseline;
+}
+
+.flex-column {
+  flex-direction: column;
+}
+
+.user-select-none {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }

--- a/js/src/lib/Details/Copyable.js
+++ b/js/src/lib/Details/Copyable.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 const images = {
   default: '/assets/detail/ico-copy-default.svg',
   success: '/assets/detail/ico-copy-success.svg',
 };
 
-export default class Copyable extends React.Component {
+export default class Copyable extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -47,14 +47,14 @@ export default class Copyable extends React.Component {
     return (
       <div className="copyable">
         <code className="copyable--code">
-          {this.props.pre}
+          <span className="user-select-none">{this.props.pre}</span>
           <span ref={sample => (this.installSample = sample)}>
             {this.props.text}
           </span>
         </code>
         <button
           onClick={() => this.copy(this.installSample)}
-          className="copyable--button"
+          className="copyable--button user-select-none"
         >
           <img
             src={this.state.statusImage}


### PR DESCRIPTION
Inspired by the package 404 page of npm, maybe some more changes are needed, I don't really want to infringe or anything

example of a 404

https://feat-404-package--yarnpkg.netlify.com/en/package/absurd-package-name

regular page: 

https://feat-404-package--yarnpkg.netlify.com/en/package/react

<img width="1082" alt="screen shot 2017-06-24 at 02 21 55" src="https://user-images.githubusercontent.com/6270048/27504068-155eb908-5884-11e7-88db-9112fb9a436e.png">