### PR TITLE
use sh shell instead of Bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
 
 reset="\033[0m"
@@ -45,12 +45,12 @@ yarn_get_tarball() {
 # Verifies the GPG signature of the tarball
 yarn_verify_integrity() {
   # Check if GPG is installed
-  if [[ -z "$(command -v gpg)" ]]; then
+  if [ -z "$(command -v gpg)" ]; then
     printf "$yellow> WARNING: GPG is not installed, integrity can not be verified!$reset\n"
     return
   fi
 
-  if [ "$YARN_GPG" == "no" ]; then
+  if [ "$YARN_GPG" = "no" ]; then
     printf "$cyan> WARNING: Skipping GPG integrity check!$reset\n"
     return
   fi
@@ -88,7 +88,7 @@ yarn_link() {
     command printf "${SOURCE_STR}"
   else
     if ! grep -q 'yarn' "$YARN_PROFILE"; then
-      if [[ $YARN_PROFILE == *"fish"* ]]; then
+      if [ $YARN_PROFILE = *"fish"* ]; then
         command fish -c 'set -U fish_user_paths $fish_user_paths ~/.yarn/bin'
       else
         command printf "$SOURCE_STR" >> "$YARN_PROFILE"
@@ -201,11 +201,11 @@ yarn_install() {
 yarn_verify_or_quit() {
   read -p "$1 [y/N] " -n 1 -r
   echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]
-  then
+  case $REPLY in [^yY]* )
     printf "$red> Aborting$reset\n"
     exit 1
-  fi
+    ;;
+  esac
 }
 
 cd ~

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 reset="\033[0m"


### PR DESCRIPTION
When installing a [nightly build](https://yarnpkg.com/en/docs/nightly) using these commands:

```
wget https://yarnpkg.com/install.sh
chmod +x install.sh
./install.sh --nightly
```

yarn installs but I get this *annoying* messages:

```terminal
./install.sh: 48: ./install.sh: [[: not found
./install.sh: 53: [: unexpected operator
```

I know a little about shell scripting & this seems to be a [bash related thing](https://stackoverflow.com/questions/669452/is-preferable-over-in-bash) (and you use bash in your [installation script](https://yarnpkg.com/en/docs/install#alternatives-tab): `curl -o- -L https://yarnpkg.com/install.sh | bash`)

I'm suggesting changing sh shebang to bash shebang based on [This Stack Overflow question](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang).

I'm using Ubuntu 17.04.