### PR TITLE
Fix the signing git tags config option

### DIFF
--- a/lang/en/docs/cli/version.md
+++ b/lang/en/docs/cli/version.md
@@ -72,10 +72,10 @@ version string:
 yarn config set version-git-message "v%s"
 ```
 
-You can also turn signing git tags on or off using `version-git-sign`:
+You can also turn signing git tags on or off using `version-sign-git-tag`:
 
 ```sh
-yarn config set version-git-sign false
+yarn config set version-sign-git-tag false
 ```
 
 You can even enabled or disable the git tagging behavior entirely by using


### PR DESCRIPTION
According to the [code](https://github.com/yarnpkg/yarn/blob/v0.27.0/src/cli/commands/version.js#L145) the option is `version-sign-git-tag` not `version-git-sign`.

Fixes https://github.com/yarnpkg/yarn/issues/3177