### PR TITLE
fix(blog): don't check for language dropdown if not i18n

### DIFF
--- a/js/src/lib/production.js
+++ b/js/src/lib/production.js
@@ -5,15 +5,17 @@ if (!NodeList.prototype.forEach) {
 export function fillLanguageDropdown() {
   // Takes over language dropdown to set cookie
   const langMenu = document.getElementById('dropdownNavLanguageMenu');
-  const langMenuItems = langMenu.querySelectorAll('dropdown-item');
+  if (langMenu) {
+    const langMenuItems = langMenu.querySelectorAll('dropdown-item');
 
-  langMenuItems.forEach(langMenuItem => {
-    langMenuItem.addEventListener('click', event => {
-      event.preventDefault();
-      const target = event.currentTarget;
-      const lang = target.dataset.lang;
-      document.cookie = `nf_lang=${lang}`;
-      location.reload();
+    langMenuItems.forEach(langMenuItem => {
+      langMenuItem.addEventListener('click', event => {
+        event.preventDefault();
+        const target = event.currentTarget;
+        const lang = target.dataset.lang;
+        document.cookie = `nf_lang=${lang}`;
+        location.reload();
+      });
     });
-  });
+  }
 }


### PR DESCRIPTION
The blog page doesn't have a language dropdown, so this event listener adding does not make sense.

fixes #546 

You can check this by seeing if there are console errors on the blog page comparing [this preview](https://deploy-preview-551--yarnpkg.netlify.com/blog) with the [live version](https://yarnpkg.com/blog)