### PR TITLE
Support installing versions that start with v

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,11 @@ yarn_get_tarball() {
   elif [ "$1" = '--rc' ]; then
     url=https://yarnpkg.com/latest-rc.tar.gz
   elif [ "$1" = '--version' ]; then
-    # Validate that the version matches MAJOR.MINOR.PATCH to avoid garbage-in/garbage-out behavior
     version=$2
+    if echo $version | grep -q "^[v]"; then
+      version=$(echo $version | cut -d "v" -f 2)
+    fi
+    # Validate that the version matches MAJOR.MINOR.PATCH to avoid garbage-in/garbage-out behavior
     if echo $version | grep -qE "^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$"; then
       url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
     else


### PR DESCRIPTION
Maybe I'm the only one who try installing a specific version with the same version shown in the release page (i.e v0.27.0): `curl -o- -L https://yarnpkg.com/install.sh | sh -s -- --version v0.27.0`

But, I think it's nice to support both ways instead of showing the error:
> Version number must match MAJOR.MINOR.PATCH.

Edit:
It seems that there're other changes to be done to support this! Sorry, I didn't notice that you're using another variable for the version `specified_version=$2`