### PR TITLE
Add note about cmdtest in Linux installation docs

### DIFF
--- a/lang/en/docs/_installations/linux.md
+++ b/lang/en/docs/_installations/linux.md
@@ -16,6 +16,8 @@ Then you can simply:
 sudo apt-get update && sudo apt-get install yarn
 ```
 
+**Note**: Ubuntu 17.04 comes with `cmdtest` installed by default. If you're getting errors from installing `yarn`, you may want to run `sudo apt remove cmdtest` first. Refer to [this](https://github.com/yarnpkg/yarn/issues/2821) for more information.
+
 ### CentOS / Fedora / RHEL
 
 On CentOS, Fedora and RHEL, you can install Yarn via our RPM package repository.


### PR DESCRIPTION
This is quite a common gotcha for people trying to install `yarn` on Ubuntu 17.04. Would be nice if it was included in the documentation to provide an early heads up.

Refer to [this](https://github.com/yarnpkg/yarn/issues/2821) for more details.