### PR TITLE
Add GPG verification commands to tarball instructions

### DIFF
--- a/lang/en/docs/_installations/tarball.md
+++ b/lang/en/docs/_installations/tarball.md
@@ -30,3 +30,11 @@ wget https://yarnpkg.com/latest.tar.gz
 tar zvxf latest.tar.gz
 # Yarn is now in /opt/yarn-[version]/
 ```
+
+Before extracting Yarn, it is recommended that you verify the tarball using GPG:
+```sh
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import
+wget https://yarnpkg.com/latest.tar.gz.asc
+gpg --verify latest.tar.gz.asc
+# Look for "Good signature from 'Yarn Packaging'" in the output
+```

--- a/lang/en/docs/_installations/tarball.md
+++ b/lang/en/docs/_installations/tarball.md
@@ -33,7 +33,7 @@ tar zvxf latest.tar.gz
 
 Before extracting Yarn, it is recommended that you verify the tarball using GPG:
 ```sh
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import
+wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import
 wget https://yarnpkg.com/latest.tar.gz.asc
 gpg --verify latest.tar.gz.asc
 # Look for "Good signature from 'Yarn Packaging'" in the output


### PR DESCRIPTION
Add the GPG verification commands in the manual installation instructions so that people are more likely to actually do it when manually installing Yarn.