### PR TITLE
Make nightly installer oneliner consistent with other installation docs

### DIFF
--- a/lang/en/docs/_installations/nightly.md
+++ b/lang/en/docs/_installations/nightly.md
@@ -2,9 +2,7 @@
 
 The easiest way of installing a nightly build is via our shell script:
 ```sh
-wget https://yarnpkg.com/install.sh
-chmod +x install.sh
-./install.sh --nightly
+curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --nightly
 ```
 
 An Ubuntu/Debian repository of the nightly builds is also available. To enable it, run the following commands:


### PR DESCRIPTION
Easiest way was not the easiest way. It's now changed to a oneliner to make it easier and consistent with *install a specific version* document.

Ref: https://github.com/yarnpkg/website/blob/master/lang/en/docs/_installations/tarball.md#installation-script