### PR TITLE
feat(Search): allow to click on a keyword to refine it

### DIFF
--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -282,9 +282,8 @@ $ais-muted-color: rgba(black,.5);
       border-bottom: dotted 1px;
     }
 
-    &:hover,
-    &:visited {
-      text-decoration: none;
+    &:hover {
+      cursor: pointer;
     }
   }
 

--- a/js/src/lib/Hit/index.js
+++ b/js/src/lib/Hit/index.js
@@ -11,7 +11,11 @@ import {
 } from '../util';
 
 export const License = ({ type }) =>
-  type ? <span className="ais-Hit--license">{type}</span> : null;
+  type
+    ? <span className="ais-Hit--license">
+        {type}
+      </span>
+    : null;
 
 export const Deprecated = ({ deprecated }) =>
   deprecated
@@ -73,7 +77,7 @@ export const Links = ({ name, homepage, githubRepo, className }) =>
       : null}
   </div>;
 
-const Hit = ({ hit }) =>
+const Hit = ({ hit, onTagClick }) =>
   <div className="ais-Hits--item">
     <a className="ais-Hit--name" href={packageLink(hit.name)}>
       <Highlight attributeName="name" hit={hit} />
@@ -84,7 +88,9 @@ const Hit = ({ hit }) =>
     />
     <License type={hit.license} />
     <Deprecated deprecated={hit.deprecated} />
-    <span className="ais-Hit--version">{hit.version}</span>
+    <span className="ais-Hit--version">
+      {hit.version}
+    </span>
     <p className="ais-Hit--description">
       {hit.deprecated
         ? hit.deprecated
@@ -106,7 +112,12 @@ const Hit = ({ hit }) =>
     {isEmpty(hit.keywords)
       ? null
       : <span className="ais-Hit--keywords hidden-sm-down">
-          {formatKeywords(hit.keywords, hit._highlightResult.keywords)}
+          {formatKeywords(
+            hit.keywords,
+            hit._highlightResult.keywords,
+            4,
+            onTagClick
+          )}
         </span>}
     <Links
       className="ais-Hit--links"

--- a/js/src/lib/Search/Results.js
+++ b/js/src/lib/Search/Results.js
@@ -12,7 +12,7 @@ import { isEmpty } from '../util';
 
 const body = document.querySelector('body');
 
-const ResultsFound = ({ pagination }) =>
+const ResultsFound = ({ pagination, onTagClick }) =>
   <div className="container">
     <div className="mx-3">
       <CurrentRefinements />
@@ -28,7 +28,9 @@ const ResultsFound = ({ pagination }) =>
         }}
       />
     </div>
-    <Hits hitComponent={Hit} />
+    <Hits
+      hitComponent={({ hit }) => <Hit onTagClick={onTagClick} hit={hit} />}
+    />
     <div className="d-flex">
       {pagination
         ? <Pagination showFirst={false} showLast={false} scrollTo={true} />
@@ -55,7 +57,7 @@ const Results = createConnector({
       : false;
     return { query: searchState.query, noResults, pagination };
   },
-})(({ noResults, query, pagination }) => {
+})(({ noResults, query, pagination, onTagClick }) => {
   if (isEmpty(query)) {
     body.classList.remove('searching');
     return <span />;
@@ -63,18 +65,28 @@ const Results = createConnector({
     body.classList.add('searching');
     const docMessage = window.i18n.no_results_docsearch.split(/[{}]+/);
     docMessage[docMessage.indexOf('documentation_link')] = (
-      <a href={`${window.i18n.url_base}/docs`}>{window.i18n.documentation}</a>
+      <a href={`${window.i18n.url_base}/docs`}>
+        {window.i18n.documentation}
+      </a>
     );
 
     return (
       <div className="container text-center mt-5">
-        <p>{window.i18n.no_package_found.replace('{name}', query)}</p>
-        <p>{docMessage.map((val, index) => <span key={index}>{val}</span>)}</p>
+        <p>
+          {window.i18n.no_package_found.replace('{name}', query)}
+        </p>
+        <p>
+          {docMessage.map((val, index) =>
+            <span key={index}>
+              {val}
+            </span>
+          )}
+        </p>
       </div>
     );
   } else {
     body.classList.add('searching');
-    return <ResultsFound pagination={pagination} />;
+    return <ResultsFound pagination={pagination} onTagClick={onTagClick} />;
   }
 });
 

--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { Component } from 'react';
 import qs from 'qs';
 import { Configure, InstantSearch } from 'react-instantsearch/dom';
+import { connectRefinementList } from 'react-instantsearch/connectors';
 
 import SearchBox from './SearchBox';
 import Results from './Results';
@@ -11,43 +12,66 @@ import { algolia } from '../config';
 // think: createreactnative instead of create-react-native-app
 const concat = string => string.replace(/[-/@_.]+/g, '');
 
-const Search = props =>
-  <InstantSearch
-    appId={algolia.appId}
-    apiKey={algolia.apiKey}
-    indexName={algolia.indexName}
-    searchState={props.searchState}
-    onSearchStateChange={props.onSearchStateChange}
-  >
-    <Configure
-      hitsPerPage={5}
-      optionalFacetFilters={
-        props.searchState.query &&
-        `concatenatedName:${concat(props.searchState.query)}`
-      }
-      facets={['keywords']}
-      attributesToRetrieve={[
-        'deprecated',
-        'description',
-        'downloadsLast30Days',
-        'githubRepo',
-        'homepage',
-        'humanDownloadsLast30Days',
-        'keywords',
-        'license',
-        'modified',
-        'name',
-        'owner',
-        'version',
-      ]}
-    />
-    <SearchBox
-      autoFocus={window.location.pathname.includes('/packages')}
-      translations={{
-        placeholder: window.i18n.search_placeholder,
-      }}
-    />
-    <Results />
-  </InstantSearch>;
+const VirtualRefinementList = connectRefinementList(() => null);
+
+class Search extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { tags: new Set() };
+    this.saveTags = this.saveTags.bind(this);
+  }
+
+  saveTags(newTags) {
+    this.setState(({ tags }) => ({ tags: tags.add(...newTags) }));
+  }
+
+  render() {
+    const {
+      searchState,
+      onSearchStateChange,
+      searchState: { query },
+    } = this.props;
+    return (
+      <InstantSearch
+        appId={algolia.appId}
+        apiKey={algolia.apiKey}
+        indexName={algolia.indexName}
+        searchState={searchState}
+        onSearchStateChange={onSearchStateChange}
+      >
+        <Configure
+          hitsPerPage={5}
+          optionalFacetFilters={query && `concatenatedName:${concat(query)}`}
+          facets={['keywords']}
+          attributesToRetrieve={[
+            'deprecated',
+            'description',
+            'downloadsLast30Days',
+            'githubRepo',
+            'homepage',
+            'humanDownloadsLast30Days',
+            'keywords',
+            'license',
+            'modified',
+            'name',
+            'owner',
+            'version',
+          ]}
+        />
+        <SearchBox
+          autoFocus={window.location.pathname.includes('/packages')}
+          translations={{
+            placeholder: window.i18n.search_placeholder,
+          }}
+        />
+        <VirtualRefinementList
+          attributeName="keywords"
+          defaultRefinement={[...this.state.tags]}
+        />
+        <Results onTagClick={this.saveTags} />
+      </InstantSearch>
+    );
+  }
+}
 
 export default withUrlSync(Search);

--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -57,11 +57,7 @@ class Search extends Component {
   }
 
   render() {
-    const {
-      searchState,
-      onSearchStateChange,
-      searchState: { query },
-    } = this.props;
+    const { searchState, onSearchStateChange } = this.props;
 
     return (
       <InstantSearch
@@ -73,7 +69,9 @@ class Search extends Component {
       >
         <Configure
           hitsPerPage={5}
-          optionalFacetFilters={query && `concatenatedName:${concat(query)}`}
+          optionalFacetFilters={
+            searchState.query && `concatenatedName:${concat(searchState.query)}`
+          }
           facets={['keywords']}
           attributesToRetrieve={[
             'deprecated',

--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import qs from 'qs';
 import { Configure, InstantSearch } from 'react-instantsearch/dom';
 import { connectRefinementList } from 'react-instantsearch/connectors';
 

--- a/js/src/lib/Search/index.js
+++ b/js/src/lib/Search/index.js
@@ -12,7 +12,7 @@ import { algolia } from '../config';
 const concat = string => string.replace(/[-/@_.]+/g, '');
 
 const equals = (arr1, arr2) =>
-  arr1.length == arr2.length && arr1.reduce((a, b, i) => a && arr2[i], true);
+  arr1.length === arr2.length && arr1.reduce((a, b, i) => a && arr2[i], true);
 
 class RefinementList extends Component {
   componentWillReceiveProps(newProps) {

--- a/js/src/lib/util.js
+++ b/js/src/lib/util.js
@@ -95,7 +95,7 @@ export function formatKeywords(
           <span
             className="ais-Hit--keyword"
             key={`${keyword}${keywordIndex}`}
-            onClick={() => onClick([keyword])}
+            onClick={() => onClick(keyword)}
           >
             {content}
           </span>

--- a/js/src/lib/util.js
+++ b/js/src/lib/util.js
@@ -45,7 +45,8 @@ export const Keywords = ({ keywords = [], maxKeywords = 4 }) => {
 export function formatKeywords(
   keywords = [],
   highlightedKeywords = [],
-  maxKeywords = 4
+  maxKeywords = 4,
+  onClick
 ) {
   if (isEmpty(keywords)) return keywords;
   highlightedKeywords.forEach((el, i) => {
@@ -91,7 +92,11 @@ export function formatKeywords(
           );
         });
         return (
-          <span className="ais-Hit--keyword" key={`${keyword}${keywordIndex}`}>
+          <span
+            className="ais-Hit--keyword"
+            key={`${keyword}${keywordIndex}`}
+            onClick={() => onClick([keyword])}
+          >
             {content}
           </span>
         );
@@ -107,9 +112,8 @@ function parseHighlightedAttribute({
 }) {
   const splitByPreTag = highlightedValue.split(preTag);
   const firstValue = splitByPreTag.shift();
-  const elements = firstValue === ''
-    ? []
-    : [{ value: firstValue, isHighlighted: false }];
+  const elements =
+    firstValue === '' ? [] : [{ value: firstValue, isHighlighted: false }];
 
   if (postTag === preTag) {
     let isHighlighted = true;


### PR DESCRIPTION
Hey, 

So what happens here, is that we add a refinementList which renders nothing, but is used for its logic alone. When someone clicks on a keyword, it gets refined and shown in `currentRefinements`, and when a refinement is removed from there or another widget, it gets unrefined too.

This was an experimentation to see if this pattern was possible (so for that, yes it works @mthuret, @kikobeats)