### PR TITLE
Replace yarn.fyi with yarn.pm

### DIFF
--- a/js/src/lib/Details/Links.js
+++ b/js/src/lib/Details/Links.js
@@ -27,11 +27,9 @@ const Links = ({ name, homepage, githubRepo, className }) =>
       site="yarn"
       display={
         <Copyable>
-          <a href={`https://yarn.fyi/${name}`}>
-            <span className="text-hide">
-              https://
-            </span>
-            yarn.fyi/{name}
+          <a href={`https://yarn.pm/${name}`}>
+            <span className="text-hide">https://</span>
+            yarn.pm/{name}
           </a>
         </Copyable>
       }

--- a/lang/en/package.html
+++ b/lang/en/package.html
@@ -31,7 +31,7 @@ for the implementation, look at /js/lib/Details/index.js etc.
         <div class="detail-links">
           <div target="_blank" rel="noopener noreferrer" class="details-links--link details-links--link__yarn"><img src="/assets/search/ico-yarn.svg" alt="">
             <div class="copyable">
-              <div class="copyable--content"><span><a href="https://yarn.fyi/…"><!-- react-text: 28 -->yarn.fyi/<!-- /react-text --><!-- react-text: 29 -->…<!-- /react-text --></a></span></div>
+              <div class="copyable--content"><span><a href="https://yarn.pm/…"><!-- react-text: 28 -->yarn.pm/<!-- /react-text --><!-- react-text: 29 -->…<!-- /react-text --></a></span></div>
               <button
                 class="copyable--button user-select-none"><img src="/assets/detail/ico-copy-default.svg" alt="" class="copyable--button__img">
                 <!-- react-text: 32 -->copy


### PR DESCRIPTION
I saw a link to https://hex.pm/ somewhere which made me discover that there's a `.pm` TLD. Nice! pm = package manager. 😛 

I picked up the `yarn.pm` domain and made it do the same thing as `yarn.fyi`.