### PR TITLE
fix(stargazers): put 0 stargazers if a GitHub repo is available but 404s

### DIFF
--- a/js/src/lib/Details/index.js
+++ b/js/src/lib/Details/index.js
@@ -267,9 +267,7 @@ class Details extends Component {
         devDependencies={this.state.devDependencies}
         dependents={this.state.dependents}
         humanDependents={this.state.humanDependents}
-        stargazers={
-          this.state.github ? this.state.github.stargazers_count : false
-        }
+        stargazers={this.state.github ? this.state.github.stargazers_count : 0}
         versions={this.state.versions}
         tags={this.state.tags}
         onOpenFileBrowser={this._openFileBrowser}


### PR DESCRIPTION
This happens for example in [yarn.pm/react-condition](https://yarn.pm/react-condition)

`(false >= 0) === true`, which makes stuff more complicated, which is why I just gave it 0.

fixes #621