### PR TITLE
Fix: Make install.sh Alpine linux compatible

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,8 +33,7 @@ yarn_get_tarball() {
     yarn_verify_integrity $tarball_tmp
 
     printf "$cyan> Extracting to ~/.yarn...$reset\n"
-    mkdir .yarn
-    tar zxf $tarball_tmp -C .yarn --strip 1 # extract tarball
+    temp=$(mktemp -d) && tar zxf $tarball_tmp -C "$temp" && mkdir .yarn && mv "$temp"/*/* .yarn && rm -rf "$temp"
     rm $tarball_tmp*
   else
     printf "$red> Failed to download $url.$reset\n"

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,12 @@ yarn_get_tarball() {
     yarn_verify_integrity $tarball_tmp
 
     printf "$cyan> Extracting to ~/.yarn...$reset\n"
-    temp=$(mktemp -d) && tar zxf $tarball_tmp -C "$temp" && mkdir .yarn && mv "$temp"/*/* .yarn && rm -rf "$temp"
+    # All this dance is because `tar --strip=1` does not work everywhere
+    temp=$(mktemp -d)
+    tar zxf $tarball_tmp -C "$temp"
+    mkdir .yarn
+    mv "$temp"/*/* .yarn
+    rm -rf "$temp"
     rm $tarball_tmp*
   else
     printf "$red> Failed to download $url.$reset\n"


### PR DESCRIPTION
**Summary**

Alpine Linux comes with BusyBox tar, which lacks the `--strip` option. This patch updates the `install.sh` script to not rely on this option.

Resolves https://github.com/yarnpkg/yarn/issues/4280.

**Test plan**

Manually verified on local Ubuntu for Windows.