### PR TITLE
Fix: make install.sh compatible with pre-Sierra OSX (#647)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ yarn_get_tarball() {
 
     printf "$cyan> Extracting to ~/.yarn...$reset\n"
     # All this dance is because `tar --strip=1` does not work everywhere
-    temp=$(mktemp -d)
+    temp=$(mktemp -d yarn.XXXXXXXXXX)
     tar zxf $tarball_tmp -C "$temp"
     mkdir .yarn
     mv "$temp"/*/* .yarn


### PR DESCRIPTION
Documented in: https://github.com/yarnpkg/website/issues/647

basically older versions of OSX require a template always to be passed to `mktemp`