### PR TITLE
fix(install): show node support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,10 @@ latest_rc_version: 1.0.0
 # the most recent stable version).
 show_rc: false
 
+# The versions of node that Yarn supports
+# This is visible on the install page
+node_support: ^4.8.0 and >= 5.7.0
+
 gacode: "UA-85522875-1"
 
 exclude:

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -11,6 +11,7 @@ site_nav_packages: Packages
 site_nav_blog: Blog
 site_nav_stable_version: Stable
 site_nav_rc_version: Release Candidate
+site_nav_node_support: Node
 
 site_bsd_license: Distributed under BSD License
 site_code_of_conduct: Code of Conduct

--- a/_includes/version-and-compatibility.html
+++ b/_includes/version-and-compatibility.html
@@ -1,0 +1,25 @@
+<div class="mt-4">
+  <div>
+    {{i18n.site_nav_stable_version}}:
+    <strong class="navbar-text">
+      <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_version}}">
+        v{{site.latest_version}}
+      </a>
+    </strong>
+    {% if site.show_rc %}
+    <span aria-hidden="true">&bull;</span>
+    {{i18n.site_nav_rc_version}}
+    <strong>
+      <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_rc_version}}">
+        v{{site.latest_rc_version}}
+      </a>
+    </strong>
+    {% endif %}
+  </div>
+  <div>
+    {{i18n.site_nav_node_support}}: 
+    <strong>
+      {{site.node_support}}
+    </strong>
+  </div>
+</div>

--- a/_layouts/pages/install.html
+++ b/_layouts/pages/install.html
@@ -1,6 +1,6 @@
 ---
 layout: guide
-hero_subtext: version.html
+hero_subtext: version-and-compatibility.html
 scripts:
   - "/js/build/install.js"
 ---


### PR DESCRIPTION
You can change which versions of node we support in _config.yml#node_support

I put it visible on /en/docs/install

looks like: 

<img width="344" alt="screen shot 2017-09-13 at 10 15 33" src="https://user-images.githubusercontent.com/6270048/30366996-453d4530-986d-11e7-9226-245c1e4e3f62.png">


fixes #646 