### PR TITLE
fix(list): rename ls to list in subcommands

### DIFF
--- a/lang/en/docs/cli/cache.md
+++ b/lang/en/docs/cli/cache.md
@@ -4,10 +4,10 @@ guide: docs_cli
 layout: guide
 ---
 
-##### `yarn cache ls` <a class="toc" id="toc-yarn-cache-ls" href="#toc-yarn-cache-ls"></a>
+##### `yarn cache list` <a class="toc" id="toc-yarn-cache-list" href="#toc-yarn-cache-list"></a>
 
 Yarn stores every package in a global cache in your user directory on the file
-system. `yarn cache ls` will print out every cached package.
+system. `yarn cache list` will print out every cached package.
 
 ##### `yarn cache dir` <a class="toc" id="toc-yarn-cache-dir" href="#toc-yarn-cache-dir"></a>
 

--- a/lang/en/docs/cli/cache.md
+++ b/lang/en/docs/cli/cache.md
@@ -4,7 +4,7 @@ guide: docs_cli
 layout: guide
 ---
 
-##### `yarn cache list` <a class="toc" id="toc-yarn-cache-list" href="#toc-yarn-cache-list"></a>
+##### `yarn cache list` <a class="toc" id="toc-yarn-cache-ls" href="#toc-yarn-cache-ls"></a>
 
 Yarn stores every package in a global cache in your user directory on the file
 system. `yarn cache list` will print out every cached package.

--- a/lang/en/docs/cli/licenses.md
+++ b/lang/en/docs/cli/licenses.md
@@ -6,14 +6,14 @@ layout: guide
 
 <p class="lead">List licenses for installed packages.</p>
 
-##### `yarn licenses ls` <a class="toc" id="toc-yarn-licenses-ls" href="#toc-yarn-licenses-ls"></a>
+##### `yarn licenses list` <a class="toc" id="toc-yarn-licenses-list" href="#toc-yarn-licenses-list"></a>
 
 Running this command will list, in alphabetical order all of the packages that
 were installed by `yarn` or `yarn install`, and give you the license (and URL
 to the source code) associated with each package.
 
 ```sh
-yarn licenses ls
+yarn licenses list
 ```
 
 ```

--- a/lang/en/docs/cli/licenses.md
+++ b/lang/en/docs/cli/licenses.md
@@ -6,7 +6,7 @@ layout: guide
 
 <p class="lead">List licenses for installed packages.</p>
 
-##### `yarn licenses list` <a class="toc" id="toc-yarn-licenses-list" href="#toc-yarn-licenses-list"></a>
+##### `yarn licenses list` <a class="toc" id="toc-yarn-licenses-ls" href="#toc-yarn-licenses-ls"></a>
 
 Running this command will list, in alphabetical order all of the packages that
 were installed by `yarn` or `yarn install`, and give you the license (and URL

--- a/lang/en/docs/cli/owner.md
+++ b/lang/en/docs/cli/owner.md
@@ -25,7 +25,7 @@ roles, but not at this time.
 
 ### Commands <a class="toc" id="toc-commands" href="#toc-commands"></a>
 
-##### `yarn owner ls <package>` <a class="toc" id="toc-yarn-owner-ls" href="#toc-yarn-owner-ls"></a>
+##### `yarn owner list <package>` <a class="toc" id="toc-yarn-owner-list" href="#toc-yarn-owner-list"></a>
 
 Lists all of the owners of a `<package>`.
 

--- a/lang/en/docs/cli/owner.md
+++ b/lang/en/docs/cli/owner.md
@@ -25,7 +25,7 @@ roles, but not at this time.
 
 ### Commands <a class="toc" id="toc-commands" href="#toc-commands"></a>
 
-##### `yarn owner list <package>` <a class="toc" id="toc-yarn-owner-list" href="#toc-yarn-owner-list"></a>
+##### `yarn owner list <package>` <a class="toc" id="toc-yarn-owner-ls" href="#toc-yarn-owner-ls"></a>
 
 Lists all of the owners of a `<package>`.
 

--- a/lang/en/docs/cli/tag.md
+++ b/lang/en/docs/cli/tag.md
@@ -72,7 +72,7 @@ Remove a tag named `<tag>` from a `<package>` that is no longer in use.
 > **Note:** You do not need to delete a tag before moving it to another
 > version in the package. It's better not to.
 
-##### `yarn tag list [<package>]` <a class="toc" id="toc-yarn-tag-list" href="#toc-yarn-tag-list"></a>
+##### `yarn tag list [<package>]` <a class="toc" id="toc-yarn-tag-ls" href="#toc-yarn-tag-ls"></a>
 
 List all of the tags for a `<package>`. If unspecified `<package>` will
 default to the package you're currently inside the directory of.

--- a/lang/en/docs/cli/tag.md
+++ b/lang/en/docs/cli/tag.md
@@ -72,7 +72,7 @@ Remove a tag named `<tag>` from a `<package>` that is no longer in use.
 > **Note:** You do not need to delete a tag before moving it to another
 > version in the package. It's better not to.
 
-##### `yarn tag ls [<package>]` <a class="toc" id="toc-yarn-tag-ls" href="#toc-yarn-tag-ls"></a>
+##### `yarn tag list [<package>]` <a class="toc" id="toc-yarn-tag-list" href="#toc-yarn-tag-list"></a>
 
 List all of the tags for a `<package>`. If unspecified `<package>` will
 default to the package you're currently inside the directory of.

--- a/lang/en/docs/cli/team.md
+++ b/lang/en/docs/cli/team.md
@@ -28,7 +28,7 @@ Add a user to an existing team.
 
 Remove a user from a team they belong to.
 
-##### `yarn team ls <scope>|<scope:team>` <a class="toc" id="toc-yarn-team-ls" href="#toc-yarn-team-ls"></a>
+##### `yarn team list <scope>|<scope:team>` <a class="toc" id="toc-yarn-team-list" href="#toc-yarn-team-list"></a>
 
 If performed on an organization name, will return a list of existing teams under that organization. If performed on a team, it will instead return a list of all users belonging to that particular team.
 

--- a/lang/en/docs/cli/team.md
+++ b/lang/en/docs/cli/team.md
@@ -28,7 +28,7 @@ Add a user to an existing team.
 
 Remove a user from a team they belong to.
 
-##### `yarn team list <scope>|<scope:team>` <a class="toc" id="toc-yarn-team-list" href="#toc-yarn-team-list"></a>
+##### `yarn team list <scope>|<scope:team>` <a class="toc" id="toc-yarn-team-ls" href="#toc-yarn-team-ls"></a>
 
 If performed on an organization name, will return a list of existing teams under that organization. If performed on a team, it will instead return a list of all users belonging to that particular team.
 


### PR DESCRIPTION
These are all the places I could find with `ls`. This should be okay without any special changes to Crowdin or whatever, since no files changed.

fixes #660