### PR TITLE
Fix grammar error in `autoclean.md`

### DIFF
--- a/lang/en/docs/cli/autoclean.md
+++ b/lang/en/docs/cli/autoclean.md
@@ -17,7 +17,7 @@ Autoclean functionality is **disabled** by default. To enable it, manually creat
 When the `.yarnclean` file exists in a package, autoclean functionality will be enabled. The clean will be performed:
 
 * After an `install`
-* After as `add`
+* After an `add`
 * If `yarn autoclean --force` is run
 
 The clean is performed by reading each line of the `.yarnclean` file and using each as a glob pattern of files to delete.


### PR DESCRIPTION
I believe the following line makes more sense as to how `.yarnclean` works:

> After an `add`

vs what's currently written:

> After as `add`