### PR TITLE
Allow link interaction in Read More sections

### DIFF
--- a/_sass/_readmore.scss
+++ b/_sass/_readmore.scss
@@ -12,6 +12,7 @@
       height: 250px;
       width: 100%;
       box-shadow: inset 0 -100px 60px -60px white;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
On a package pages with links in the readme (such as https://yarnpkg.com/en/package/ldap-promise), there are links visible but they are not clickable, even though the text is selectable with a mouse.  This CSS change prevents the pointer from interacting with the read more overlay, meaning the browser can interact with links and other UI elements.

The previous workaround was to open the read more section, but this is non-intuitive.