### PR TITLE
Updates CLI output of `yarn outdated`

### DIFF
--- a/lang/en/docs/cli/outdated.md
+++ b/lang/en/docs/cli/outdated.md
@@ -28,9 +28,9 @@ yarn outdated
 ```
 
 ```
-Package    Current Wanted Latest
-lodash     4.15.0  4.15.0 4.16.4
-underscore 1.6.0   1.6.0  1.8.3 
+Package    Current Wanted Latest Package Type    URL
+lodash     4.15.0  4.15.0 4.16.4 devDependencies https://github.com/lodash/lodash#readme
+underscore 1.6.0   1.6.0  1.8.3  dependencies    https://github.com/jashkenas/underscore#readme
 ✨  Done in 0.72s.
 ```
 
@@ -46,7 +46,7 @@ yarn outdated lodash
 ```
 
 ```
-Package Current Wanted Latest
-lodash  4.15.0  4.15.0 4.16.4
+Package Current Wanted Latest Package Type    URL
+lodash  4.15.0  4.15.0 4.16.4 devDependencies https://github.com/lodash/lodash#readme
 ✨  Done in 1.04s.
 ```


### PR DESCRIPTION
Hey :wave:

I noticed that the CLI output of `yarn outdated` doesn't seem to be up-to-date, so I added the additional `Package Type` and `URL` information.