### PR TITLE
fix(details): manually sanitize relative svgs

### DIFF
--- a/js/src/lib/Details/Markdown.js
+++ b/js/src/lib/Details/Markdown.js
@@ -27,12 +27,16 @@ const renderAndEscapeMarkdown = ({ source, githubRepo }) => {
       });
 
     // manually ask for sanitation of svgs, otherwise it will have wrong content-type
-    const sanitize = href =>
-      `${href}${href.indexOf('//') === -1 &&
-      String.prototype.endsWith &&
-      href.endsWith('.svg')
-        ? '?sanitize=true'
-        : ''}`;
+    function sanitize(href) {
+      if (
+        href.indexOf('//') === -1 &&
+        String.prototype.endsWith &&
+        href.endsWith('.svg')
+      ) {
+        return `${href}?sanitize=true`;
+      }
+      return href;
+    }
 
     renderer.image = (href, title, text) =>
       `<img src="${prefix(

--- a/js/src/lib/Details/Markdown.js
+++ b/js/src/lib/Details/Markdown.js
@@ -26,8 +26,17 @@ const renderAndEscapeMarkdown = ({ source, githubRepo }) => {
         path,
       });
 
+    // manually ask for sanitation of svgs, otherwise it will have wrong content-type
+    const sanitize = href =>
+      `${href}${String.prototype.endsWith && href.endsWith('.svg')
+        ? '?sanitize=true'
+        : ''}`;
+
     renderer.image = (href, title, text) =>
-      `<img src="${prefix(href, GITHUB.raw)}" title="${title}" alt="${text}"/>`;
+      `<img src="${prefix(
+        sanitize(href),
+        GITHUB.raw
+      )}" title="${title}" alt="${text}"/>`;
 
     renderer.link = (href, title, text) => {
       // wrongly linked comments

--- a/js/src/lib/Details/Markdown.js
+++ b/js/src/lib/Details/Markdown.js
@@ -28,7 +28,9 @@ const renderAndEscapeMarkdown = ({ source, githubRepo }) => {
 
     // manually ask for sanitation of svgs, otherwise it will have wrong content-type
     const sanitize = href =>
-      `${href}${String.prototype.endsWith && href.endsWith('.svg')
+      `${href}${href.indexOf('//') === -1 &&
+      String.prototype.endsWith &&
+      href.endsWith('.svg')
         ? '?sanitize=true'
         : ''}`;
 


### PR DESCRIPTION
GitHub will return the wrong content-type and it will result in a broken image. This fix is only added in situations where String has `endsWith`, but that's okay since it's a very niche usecase

check: `@code-therapy/packages-with-readme-relative-images`

fixes #692 

cc @smotaal