### PR TITLE
fix(details): handle case where GitHub link 404s

### DIFF
--- a/js/src/lib/Details/index.js
+++ b/js/src/lib/Details/index.js
@@ -133,7 +133,7 @@ class Details extends Component {
 
   maybeRenderReadme() {
     if (this.state.loaded) {
-      const { readme } = this.state;
+      const { readme = '' } = this.state;
       if (readme.length === 0 || readme === readmeErrorMessage) {
         return <div>{window.i18n.detail.no_readme_found}</div>;
       }


### PR DESCRIPTION
An example for this one is `duivvv` which has the "no readme data" from npm, then we fallback to GitHub, but the repo doesn't exist. It then throws an error because the readme is now `undefined`, which has no `length`. So we add a default to readme of an empty string