### PR TITLE
fix(search): don't cause rerenders of SearchBox component

### DIFF
--- a/js/src/lib/Search/SearchBox.js
+++ b/js/src/lib/Search/SearchBox.js
@@ -2,25 +2,24 @@ import React, { Component } from 'react';
 import { SearchBox } from 'react-instantsearch/dom';
 
 class WrappedSearchBox extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { active: false };
-  }
+  state = { active: false };
+
+  handleFocus = () =>
+    this.setState({
+      active: true,
+    });
+
+  handleBlur = () =>
+    this.setState({
+      active: false,
+    });
 
   render() {
     return (
       <div className={this.state.active ? 'active' : ''}>
         <SearchBox
-          onFocus={() => {
-            this.setState({
-              active: true,
-            });
-          }}
-          onBlur={() => {
-            this.setState({
-              active: false,
-            });
-          }}
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
           {...this.props}
         />
       </div>


### PR DESCRIPTION
Because the referential equality of these two functions is different, it caused the SearchBox to rerender, and thus send a new query.