### PR TITLE
add yarn global dir

### DIFF
--- a/lang/en/docs/cli/global.md
+++ b/lang/en/docs/cli/global.md
@@ -28,6 +28,8 @@ $ create-react-app
 
 `yarn global bin` will output the location where Yarn will install symlinks to your installed executables. You can configure the base location with `yarn config set prefix <filepath>`. For example, `yarn config set prefix ~/.yarn` will ensure all global packages will have their executables installed to `~/.yarn/bin`.
 
+`yarn global dir` will print the output of the global installation folder that houses the global `node_modules`. By default that will be: `~/.config/yarn/global`.
+
 Read more about the commands that can be used together with `yarn global`:
 
 - [`yarn add`]({{url_base}}/docs/cli/add): add a package to use in your current package.


### PR DESCRIPTION
I didn't add this as a `yarn dir` command link, because it doesn't exist

ref: https://github.com/yarnpkg/yarn/pull/4522 and https://github.com/yarnpkg/yarn/issues/2652