### PR TITLE
docs(contributing): Update with sections from `yarn` CONTRIBUTING.md

### DIFF
--- a/lang/en/org/contributing.md
+++ b/lang/en/org/contributing.md
@@ -9,6 +9,25 @@ layout: guide
 Contributions are always welcome, no matter how large or small. Before contributing,
 please read the [code of conduct]({{url_base}}/org/code-of-conduct).
 
+## Find things to work on
+
+We label issues that we need help with the `help wanted` tag. We also categorize them with the following tags:
+
+ - cat-bug
+ - cat-feature
+ - cat-chore
+ - cat-performance
+
+These are the main categories that you can work on. We further mark issues with a `high-priority` tag or a `good first issue` tag to indicate their importance to the project and subjective level of easiness to get started on respectively. If you don't see the `triaged` tag or you see any of the `needs-confirmation`, `needs-repro-script`, `needs-discussion` tags, it may not be wise to start working on these issues.
+
+Here are a few quick links to get you started:
+
+ - [Good first bugs](https://github.com/yarnpkg/yarn/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3Atriaged+label%3Acat-bug+label%3A%22good+first+issue%22)
+ - [Good first features](https://github.com/yarnpkg/yarn/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3A%22help%20wanted%22%20label%3Atriaged%20label%3Acat-feature%20label%3A%22good%20first%20issue%22%20)
+ - [High impact issue that need help](https://github.com/yarnpkg/yarn/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3Ahigh-priority+label%3Atriaged)
+ - [Issues need reproduction scripts](https://github.com/yarnpkg/yarn/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3A%22needs-repro-script%22)
+ - [Issues need triaging](https://github.com/yarnpkg/yarn/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20-label%3Atriaged)
+
 ## Building <a class="toc" id="toc-building" href="#toc-building"></a>
 
 ```sh
@@ -17,6 +36,12 @@ yarn run build
 
 ```sh
 yarn run watch
+```
+
+## Using the local builds
+
+```sh
+alias yarn="node /path/to/yarn/lib/cli/index.js"
 ```
 
 ## Testing <a class="toc" id="toc-testing" href="#toc-testing"></a>


### PR DESCRIPTION
As @Daniel15 suggested in https://github.com/yarnpkg/yarn/pull/4803#issuecomment-340511925, contributing page on the website should also be up-to-date with the changes, so I've combined changes from https://github.com/yarnpkg/yarn/pull/4803 and https://github.com/yarnpkg/yarn/pull/4386.

It's kind of tedious to make all these changes twice, so we should think about some way of linking this page with the `CONTRIBUTING.md` from the main repo, see: https://github.com/yarnpkg/yarn/pull/4386#issuecomment-328365590. I can try to work on that if you want. Has any dependency/cross-link to `yarn` already been set up in this repo?