### PR TITLE
Missing dot

### DIFF
--- a/lang/en/docs/yarnrc.md
+++ b/lang/en/docs/yarnrc.md
@@ -62,7 +62,7 @@ Setting this number to 1 will cause the node modules to be built sequentially wh
 
 ### CLI arguments <a class="toc" id="toc-cli-arguments" href="#toc-cli-arguments"></a>
 
-Setting `--<command><flag> <value>` in .yarnrc would be the same as running `yarn <command> --<flag> <value>`.
+Setting `--<command>.<flag> <value>` in .yarnrc would be the same as running `yarn <command> --<flag> <value>`.
 
 Example:
 ```


### PR DESCRIPTION
As per line 70, there needs to be a dot between the command and the flag.