### PR TITLE
Modified docs for yarn add command

### DIFF
--- a/lang/en/docs/cli/add.md
+++ b/lang/en/docs/cli/add.md
@@ -44,8 +44,8 @@ You can also specify packages from different locations:
   haven't been published to the registry.
 3. `yarn add file:/path/to/local/tarball.tgz` installs a package from a gzipped
   tarball which could be used to share a package before publishing it.
-4. `yarn add <git remote url>` installs a package from a remote git repository.
-5. `yarn add <git remote url>#<branch/commit/tag>` installs a package from a remote
+4. `yarn add [options] -- <git remote url>` installs a package from a remote git repository.
+5. `yarn add [options] -- <git remote url>#<branch/commit/tag>` installs a package from a remote
   git repository at specific git branch, git commit or git tag.
 6. `yarn add https://my-project.org/package.tgz` installs a package from a
   remote gzipped tarball.


### PR DESCRIPTION
Added changes about how to use `yarn add` when installing from git repositories.
This commit adds ```--``` command to install packages from git repositories.
Addressed #721