### PR TITLE
Add CDNs header under Use it (#723)

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -336,6 +336,7 @@ script:
     try_in_runkit: Try in RunKit
     back_to_details: Back to Details
     browse_files: Browse Files
+    cdns: CDNs
     contributors: Contributors
     display_full_readme: Display full readme
     display_full_changelog: Display full changelog

--- a/js/src/lib/Details/Aside.js
+++ b/js/src/lib/Details/Aside.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Install from './Install';
+import Cdn from './Cdn';
 import Links from './Links';
 import Activity from './Activity';
 import Popularity from './Popularity';
@@ -32,6 +33,7 @@ const Aside = ({
       <Links name={name} homepage={homepage} githubRepo={githubRepo} />
     </article>
     <Install name={name} onOpenFileBrowser={onOpenFileBrowser} />
+    <Cdn name={name} />
     <Popularity
       downloads={downloads}
       humanDownloads={humanDownloads}

--- a/js/src/lib/Details/Cdn.js
+++ b/js/src/lib/Details/Cdn.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import { Di } from './';
+
+const JsDelivr = ({ name }) => (
+  <Di
+    title="jsDelivr"
+    description={
+      <a
+        href={`https://cdn.jsdelivr.net/npm/${name}/`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        cdn.jsdelivr.net/npm/{name}/
+      </a>
+    }
+  />
+);
+
+class Cdn extends Component {
+  render() {
+    const {
+      name,
+    } = this.props;
+
+    return (
+        <article className="details-side--cdns">
+            <h1>{window.i18n.detail.cdns}</h1>
+            <dl>
+                <JsDelivr name={name} />
+            </dl>
+        </article>
+    );
+  }
+}
+
+export default Cdn;

--- a/lang/en/package.html
+++ b/lang/en/package.html
@@ -59,6 +59,10 @@ for the implementation, look at /js/lib/Details/index.js etc.
           <!-- react-text: 52 -->·
           <!-- /react-text --><a href="#">Browse Files</a></div>
       </article>
+      <article class="details-side--cdns">
+        <h1>CDNs</h1>
+        <dl></dl>
+      </article>
       <article class="details-side--popularity">
         <h1>Popularity</h1>
         <dl></dl>


### PR DESCRIPTION
1. Adds "CDNs" (#723).
2. Replaces usage of unpkg.com API with jsDelivr API for the file browser as previously discussed, because it is more stable and built for production usage. The API is also versioned which means there are never breaking changes such as #614.