### PR TITLE
Fix minor issue referencing Lerna CLI flag

### DIFF
--- a/_posts/2017-07-26-introducing-workspaces.md
+++ b/_posts/2017-07-26-introducing-workspaces.md
@@ -202,7 +202,7 @@ Not at all. Yarn Workspaces are easily integrated with Lerna.
 
 Lerna provides a lot more than just bootstrapping a project and it has a community of users around it that have fine-tuned Lerna for their needs. 
 
-Starting with Lerna 2.0.0, when you pass the flag [--use-workspaces](https://github.com/lerna/lerna#--use-workspaces) when running Lerna commands, it will use Yarn to bootstrap the project and also it will use `package.json/workspaces` field to find the packages instead of `lerna.json/packages`.
+Starting with Lerna 2.0.0, when you pass the flag [`--use-workspaces`](https://github.com/lerna/lerna#--use-workspaces) when running Lerna commands, it will use Yarn to bootstrap the project and also it will use `package.json/workspaces` field to find the packages instead of `lerna.json/packages`.
 
 This is how Lerna is configured for Jest:
 


### PR DESCRIPTION
On the live Yarn website, the flag is rendered as –use-workspaces (notice the n-dash instead of `--` prefixing the CLI option).

This is probably due to some automatic typographical improvements that are applied at build time. I've wrapped the option in `code`, which should hopefully fix this.