### PR TITLE
Fix CDN links for packages with long names

### DIFF
--- a/_sass/_details.scss
+++ b/_sass/_details.scss
@@ -155,6 +155,14 @@
         background-image: url('/assets/detail/ico-runkit.svg');
       }
     }
+
+    &--cdns {
+      dd {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+    }
   }
 
   &-files {


### PR DESCRIPTION
Adds some CSS to make this look better: https://yarnpkg.com/en/package/ractive-component-loader