### PR TITLE
Update 2016-11-24-offline-mirror.md

### DIFF
--- a/_posts/2016-11-24-offline-mirror.md
+++ b/_posts/2016-11-24-offline-mirror.md
@@ -99,6 +99,8 @@ Let's move this file to the project root so that offline mirror would be used on
 $ mv ~/.yarnrc ./
 ```
 
+(In the unlikely event that `yarn config` didn't update the file in your home folder, e.g. if you are running `yarn config` as root inside a Docker container, the file being updated might be a different one. Use `yarn config list --verbose` to locate the proper file.)
+
 ### Initialize the new lockfile
 
 Remove node_modules and yarn.lock that were generated previously and run yarn install again:


### PR DESCRIPTION
I struggled with this for a while until I found where it was. Agreeably, running `yarn install` as root is semi-odd, but I'm currently working on a deployment pipeline where it totally makes sense. The _builders_ run everything as root inside a Docker container, the runtime Docker image runs the application inside another container as a non-privileged user.