### PR TITLE
added global bin folder to PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ yarn_verify_integrity() {
 yarn_link() {
   printf "$cyan> Adding to \$PATH...$reset\n"
   YARN_PROFILE="$(yarn_detect_profile)"
-  SOURCE_STR="\nexport PATH=\"\$HOME/.yarn/bin:\$PATH\"\n"
+  SOURCE_STR="\nexport PATH=\"\$HOME/.yarn/bin:\$HOME/.config/yarn/global/node_modules/.bin:\$PATH\"\n"
 
   if [ -z "${YARN_PROFILE-}" ] ; then
     printf "$red> Profile not found. Tried ${YARN_PROFILE} (as defined in \$PROFILE), ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile.\n"


### PR DESCRIPTION
I prefer using install.sh script for managing Yarn on my Raspberry Pi.
This seems to work both for Mac and a Raspbian OS.

@Daniel15, does it look reasonable?