### PR TITLE
Add "lerna" key to the example lerna.json

### DIFF
--- a/_posts/2017-07-26-introducing-workspaces.md
+++ b/_posts/2017-07-26-introducing-workspaces.md
@@ -208,6 +208,7 @@ This is how Lerna is configured for Jest:
 
 ```
 {
+  "lerna": "2.0.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }


### PR DESCRIPTION
If you don't do it, you'll end up with an obscure error about missing `lerna.json`.
https://github.com/lerna/lerna/issues/1067#issuecomment-357023774