### PR TITLE
fix(search): give a default in case `downloadsLast30Days` is not given

### DIFF
--- a/js/src/lib/Hit/index.js
+++ b/js/src/lib/Hit/index.js
@@ -41,7 +41,7 @@ export const Owner = ({ link, avatar, name, onClick }) => (
   </a>
 );
 
-export const Downloads = ({ downloads, humanDownloads }) => (
+export const Downloads = ({ downloads = 0, humanDownloads }) => (
   <span
     className={`ais-Hit--popular ${getDownloadBucket(downloads)}`}
     title={window.i18n.downloads_in_last_30_days.replace(


### PR DESCRIPTION
This was breaking the whole app, since we were calling `.toLocaleString()` on `undefined`, which errors.

fixes #756

cc @ajaymathur