### PR TITLE
keep markdown 1. ordering with code blocks

### DIFF
--- a/_posts/2017-07-26-introducing-workspaces.md
+++ b/_posts/2017-07-26-introducing-workspaces.md
@@ -98,7 +98,7 @@ To keep things simple I'll describe two small Workspaces packages:
     }
     ```
 
-1. jest-diff Workspace that depends on jest-matcher-utils:
+2. jest-diff Workspace that depends on jest-matcher-utils:
 
     ```
     {

--- a/_posts/2017-07-26-introducing-workspaces.md
+++ b/_posts/2017-07-26-introducing-workspaces.md
@@ -83,38 +83,38 @@ To keep things simple I'll describe two small Workspaces packages:
 
 1. jest-matcher-utils Workspace:
 
-```
-{
-  "name": "jest-matcher-utils",
-  "description": "...",
-  "version": "20.0.3",
-  "license": "...",
-  "main": "...",
-  "browser": "...",
-  "dependencies": {
-    "chalk": "^1.1.3",
-    "pretty-format": "^20.0.3"
-  }
-}
-```
+    ```
+    {
+      "name": "jest-matcher-utils",
+      "description": "...",
+      "version": "20.0.3",
+      "license": "...",
+      "main": "...",
+      "browser": "...",
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "pretty-format": "^20.0.3"
+      }
+    }
+    ```
 
-2. jest-diff Workspace that depends on jest-matcher-utils:
+1. jest-diff Workspace that depends on jest-matcher-utils:
 
-```
-{
-  "name": "jest-diff",
-  "version": "20.0.3",
-  "license": "...",
-  "main": "...",
-  "browser": "...",
-  "dependencies": {
-    "chalk": "^1.1.3",
-    "diff": "^3.2.0",
-    "jest-matcher-utils": "^20.0.3",
-    "pretty-format": "^20.0.3"
-  }
-}
-```
+    ```
+    {
+      "name": "jest-diff",
+      "version": "20.0.3",
+      "license": "...",
+      "main": "...",
+      "browser": "...",
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "diff": "^3.2.0",
+        "jest-matcher-utils": "^20.0.3",
+        "pretty-format": "^20.0.3"
+      }
+    }
+    ```
 
 A wrapper like Lerna would first run `yarn install` for each `package.json` separately and then run `yarn link` for packages that depend on each other.
 


### PR DESCRIPTION
Currently the markdown list doesn't indent the content of the code 4 spaces which causes markdown to treat each item as a new list and show `1.` for each one (Markdown doesn't care what number you give to list items). This PR uses the correct indentation and also uses `1.` for each list item which is markdown convention.

Before:
![image](https://user-images.githubusercontent.com/1187604/35841274-1fa40718-0ac9-11e8-830f-65064904a22a.png)

After:
![image](https://user-images.githubusercontent.com/1187604/35841312-4dc9701a-0ac9-11e8-82ca-061bc8565e37.png)
