### PR TITLE
doc/ubuntu nvm: Ubuntu NVM howto

### DIFF
--- a/lang/en/docs/_installations/linux.md
+++ b/lang/en/docs/_installations/linux.md
@@ -24,6 +24,8 @@ If using `nvm` you can avoid the `node` installation by doing:
 sudo apt-get install --no-install-recommends yarn
 ```
 
+**Note**: Due to the use of `nodejs` instead of `node` name in some distros, `yarn` might complain about `node` not being installed, a workaround for this is to add an alias in your `.bashrc` file, like so: `alias nodejs=node`. This will point `yarn` to whatever version of `node` you decide to use.
+
 ### CentOS / Fedora / RHEL
 
 On CentOS, Fedora and RHEL, you can install Yarn via our RPM package repository.

--- a/lang/en/docs/_installations/linux.md
+++ b/lang/en/docs/_installations/linux.md
@@ -18,6 +18,12 @@ sudo apt-get update && sudo apt-get install yarn
 
 **Note**: Ubuntu 17.04 comes with `cmdtest` installed by default. If you're getting errors from installing `yarn`, you may want to run `sudo apt remove cmdtest` first. Refer to [this](https://github.com/yarnpkg/yarn/issues/2821) for more information.
 
+If using `nvm` you can avoid the `node` installation by doing:
+
+```sh
+sudo apt-get install --no-install-recommends yarn
+```
+
 ### CentOS / Fedora / RHEL
 
 On CentOS, Fedora and RHEL, you can install Yarn via our RPM package repository.


### PR DESCRIPTION
This PR is to document `yarn` installation process in `Ubuntu` when using `nvm`, avoiding `node` installation and setup to use `nvm` version. Based on https://github.com/yarnpkg/website/issues/762.