### PR TITLE
fix(highlighting): make sure spaces in description highlight render as spaces

### DIFF
--- a/js/src/lib/util.js
+++ b/js/src/lib/util.js
@@ -230,7 +230,7 @@ inlineRenderer.paragraph = function(text) {
 };
 
 export const safeMarkdown = input => ({
-  __html: xss(marked(unescape(input), { renderer: inlineRenderer })),
+  __html: xss(marked(unescape(input), { renderer: inlineRenderer })) || ' ',
 });
 
 export const i18nReplaceVars = (message, vars) =>


### PR DESCRIPTION
The problem is that markdown will interpret a single space as identical to "nothing", whic it isn't.

So as a fix, in the code for safe highlighting of markdown, I wrote `xss(...) || ' '`, which will make sure that if nothing is returned by the markdown parser, I return a space. Technically it's possible now that in the case of a completely empty description, a single space is shown instead, but practically that can't happen, since npm will pick the beginning of the readme if the description is empty.

|before|after|
|---|---|
|<img width="598" alt="screen shot 2018-02-13 at 11 00 48" src="https://user-images.githubusercontent.com/6270048/36144066-2e7e0b6e-10ad-11e8-936d-0e00142a9f85.png">|<img width="593" alt="screen shot 2018-02-13 at 10 57 09" src="https://user-images.githubusercontent.com/6270048/36144032-1440f540-10ad-11e8-931f-55bbf016828e.png">|


cc @samouss