### PR TITLE
Use curl instead of wget on CentOS / Fedora / RHEL

### DIFF
--- a/lang/en/docs/_installations/linux.md
+++ b/lang/en/docs/_installations/linux.md
@@ -31,7 +31,7 @@ sudo apt-get install --no-install-recommends yarn
 On CentOS, Fedora and RHEL, you can install Yarn via our RPM package repository.
 
 ```sh
-sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo
+curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
 ```
 
 If you do not already have Node.js installed, you should also configure


### PR DESCRIPTION
The default install doesn't come with wget, but it does come with cURL. So this command has a better chance of working without requiring installing another dependency.