### PR TITLE
Add docs for `yarn install --verbose`

### DIFF
--- a/lang/en/docs/cli/index.md
+++ b/lang/en/docs/cli/index.md
@@ -50,3 +50,7 @@ can also specify an alternate port.
 --mutex network
 --mutex network:30330
 ```
+
+## Verbose output with `--verbose` <a class="toc" id="toc-verbose" href="#toc-verbose"></a>
+
+Running `yarn <command> --verbose` will print verbose info for the execution (creating directories, copying files, HTTP requests, etc.). 

--- a/lang/en/docs/cli/install.md
+++ b/lang/en/docs/cli/install.md
@@ -101,9 +101,3 @@ Run yarn install in offline mode.
 ##### `yarn install --non-interactive` <a class="toc" id="toc-yarn-install-non-interactive" href="#toc-yarn-install-non-interactive"></a>
 
 Disable interactive prompts, like when there's an invalid version of a dependency.
-
-##### `yarn install --verbose` <a class="toc" id="toc-yarn-install-verbose" href="#toc-yarn-install-verbose"></a>
-
-Print verbose info for the installation (creating directories, copying files, HTTP requests, etc.)
-
-

--- a/lang/en/docs/cli/install.md
+++ b/lang/en/docs/cli/install.md
@@ -101,3 +101,9 @@ Run yarn install in offline mode.
 ##### `yarn install --non-interactive` <a class="toc" id="toc-yarn-install-non-interactive" href="#toc-yarn-install-non-interactive"></a>
 
 Disable interactive prompts, like when there's an invalid version of a dependency.
+
+##### `yarn install --verbose` <a class="toc" id="toc-yarn-install-verbose" href="#toc-yarn-install-verbose"></a>
+
+Print verbose info for the installation (creating directories, copying files, HTTP requests, etc.)
+
+


### PR DESCRIPTION
Was searching for an option to print all of the info when running `yarn install` and found the exact option in an issue [#763](https://github.com/yarnpkg/yarn/issues/763) instead of having it in the docs, therefore I am adding it to the docs for future wanderers like me.