### PR TITLE
Update Shitty Watercolour Link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
 
     <div class="footer-right">
       {% if layout.shitty %}
-        <span class="footer-item"><a href="http://shittywatercolour.com/">Artwork by Shitty Watercolour</a></span>
+        <span class="footer-item"><a href="https://en.wikipedia.org/wiki/Hector_Janse_van_Rensburg">Artwork by Shitty Watercolour</a></span>
       {% endif %}
 
       {% if vars_active_language.tag == "en" %}


### PR DESCRIPTION
The webpage link to [shittywatercolour.com](shittywatercolour.com) for Shitty Watercolour's Artwork gives a 404 error. This pull request replaces the link with his [Wikipedia Page - Hector_Janse_van_Rensburg](https://en.wikipedia.org/wiki/Hector_Janse_van_Rensburg) to show credit and match his website link on [Twitter - @SWatercolour](https://twitter.com/SWatercolour).