### PR TITLE
Update CircleCI documentation.

### DIFF
--- a/lang/en/docs/_ci/circle.md
+++ b/lang/en/docs/_ci/circle.md
@@ -1,1 +1,1 @@
-Yarn is pre-installed on [CircleCI](https://circleci.com/). You can quickly get up and running by following their [Yarn documentation](https://circleci.com/docs/1.0/yarn/).
+[CircleCI](https://circleci.com/) provides documentation for Yarn. You can get up and running by following their [Yarn documentation](https://circleci.com/docs/2.0/yarn/).


### PR DESCRIPTION
Moving the link to CircleCI 2.0 as 1.0 will be sunsetted within 6 months.