### PR TITLE
fix: nit in workflow step

### DIFF
--- a/lang/en/docs/yarn-workflow.md
+++ b/lang/en/docs/yarn-workflow.md
@@ -13,5 +13,5 @@ There are a few things you should know about the basic workflow:
 1. Creating a new project
 2. Adding/updating/removing dependencies
 3. Installing/reinstalling your dependencies
-4. Working with version control (i.e. git)
+4. Working with version control (e.g. git)
 5. Continuous Integration


### PR DESCRIPTION
⛏Changes i.e. (*id est*, that is) to e.g. (*exempli gratia*, for example) as git is only one among many VCS options. As a reference, [the Spanish translation](https://yarnpkg.com/es-ES/docs/yarn-workflow) is using "por ejemplo".

*(BTW, where are the sources for translations?)*