### PR TITLE
fix(redirect): Redirect to English pages for unsupported langs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -57,6 +57,8 @@ lang/:lang/compare https://github.com/pnpm/node-package-manager-benchmark 302
         {% assign redirectsLang = redirectsLang | push: redirect %}
       {% endif %}
     {% endfor %}
+    {% capture redirect %}{{url}}  /lang/en/{{url}}  302  Language=en{% endcapture %}
+    {% assign redirectsBase = redirectsBase | push: redirect %}
   {% endfor %}
 
 {% capture newline %}


### PR DESCRIPTION
**Summary**

Fixes #385. Adds redirects to English pages for unsupported languages.

**Test plan**

Manual verification.