### PR TITLE
Less bold security claims

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -37,10 +37,11 @@ homepage_feature_fast_description: |
   faster than ever.
 homepage_feature_fast_image_alt: Watercolour of cat riding a rocketship
 
-homepage_feature_secure_title: Mega Secure.
+homepage_feature_secure_title: Moderately Secure.
 homepage_feature_secure_description: |
-  Yarn uses checksums to verify the integrity of every installed package
-  before its code is executed.
+  Yarn intends to use strong cryptographic checksums to verify the integrity of every
+  installed package before any further processing.
+  We are almost there. Any help is welcome to fix the remaining issues!
 homepage_feature_secure_image_alt: Watercolour of cat driving a robot suit
 
 homepage_feature_reliable_title: Super Reliable.


### PR DESCRIPTION
The strong security claims convey a wrong impression of the actual state of the project:

* SHA-1 hashes are used even though SHA-1 is considered deprecated for quite a long time.
* Files are partly processed before the checksum is verified (namely, it is unpacked), violating security best practices and making Yarn unnecessarily vulnerable to exploits for tar, gzip, etc., as well as zip bombs.
* The number of volunteers is too small to react quickly on those issues: The SHA-1 issue is open for 1.5 years, the verification issue is open for 0.5 years.

This all isn't bad in itself. Yarn does most things right and is nevertheless a really strong competitor to NPM. But the website should be honest on that upfront, instead of giving a false sense of security.