### PR TITLE
Migration docs for npm semver version bumping

### DIFF
--- a/lang/en/docs/migrating-from-npm.md
+++ b/lang/en/docs/migrating-from-npm.md
@@ -56,4 +56,7 @@ your existing `npm-shrinkwrap.json` file and check in the newly created `yarn.lo
 | `npm rebuild`                           | `yarn add --force`                        |
 | `npm uninstall [package]`               | `yarn remove [package]`                   |
 | `npm cache clean`                       | `yarn cache clean [package]`              |
-| `rm -rf node_modules && npm install`    | `yarn upgrade`                            |
+| `rm -rf node_modules && npm install`    | `yarn upgrade`                            |
+| `npm version major`                     | `yarn version --major`                    |
+| `npm version minor`                     | `yarn version --minor`                    |
+| `npm version patch`                     | `yarn version --patch`                    |


### PR DESCRIPTION
Especially now that yarn@1.7.0 (which ships the functionality) is released, it seems fitting to add version bumping examples to the npm migration docs