### PR TITLE
Typo in debian node alias command

### DIFF
--- a/lang/en/docs/_installations/debian.md
+++ b/lang/en/docs/_installations/debian.md
@@ -36,4 +36,4 @@ If using `nvm` you can avoid the `node` installation by doing:
 sudo apt-get install --no-install-recommends yarn
 ```
 
-**Note**: Due to the use of `nodejs` instead of `node` name in some distros, `yarn` might complain about `node` not being installed, a workaround for this is to add an alias in your `.bashrc` file, like so: `alias nodejs=node`. This will point `yarn` to whatever version of `node` you decide to use.
+**Note**: Due to the use of `nodejs` instead of `node` name in some distros, `yarn` might complain about `node` not being installed, a workaround for this is to add an alias in your `.bashrc` file, like so: `alias node=nodejs`. This will point `yarn` to whatever version of `node` you decide to use.


### PR DESCRIPTION
Works correctly edited to proper: alias node=nodejs