### PR TITLE
Guard against partial curl failures

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ yarn_get_tarball() {
   fi
   # Get both the tarball and its GPG signature
   tarball_tmp=`mktemp -t yarn.tar.gz.XXXXXXXXXX`
-  if curl --fail -L -o "$tarball_tmp#1" "$url{,.asc}"; then
+  if curl --fail-early --fail -L -o "$tarball_tmp#1" "$url{,.asc}"; then
     yarn_verify_integrity $tarball_tmp
 
     printf "$cyan> Extracting to ~/.yarn...$reset\n"


### PR DESCRIPTION
I pinged the Twitter account with this earlier. The script was failing due to a status code 520 for the primary tarball. (This is apparently a nonstandard error indicating that the server returned a non-HTTP response, and apparently has happened with Cloudflare in the past, but that's all I could turn up on that.) See image:

![screenshot_20180628_131110](https://user-images.githubusercontent.com/765551/42065854-4d8976d8-7af2-11e8-983e-9411ab628be3.png)

The issue is that the curl command is getting two files at once, but only the first file failed and not both. It seems that curl does not return an error status code if the second file is fine.

This `--fail-early` argument I found in the man page and indicates it was added for exactly this sort of situation. It only exists in curl 7.52.0 and above, which is 1.5 years old. I'm not sure if that's old enough for your intended usage here, since curl errors out on unknown arguments.

This could be refactored into a bash variable conditional on the curl version detected, if you prefer.