### PR TITLE
Updating NodeSource command to current LTS (v8)

### DIFF
--- a/lang/en/docs/_installations/centos.md
+++ b/lang/en/docs/_installations/centos.md
@@ -8,7 +8,7 @@ If you do not already have Node.js installed, you should also configure
 [the NodeSource repository](https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora):
 
 ```sh
-curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+curl --silent --location https://rpm.nodesource.com/setup_8.x | sudo bash -
 ```
 
 Then you can simply:


### PR DESCRIPTION
The current (v6) command seems to not work, and in any case I'd suggest current LTS as the way to go.