### PR TITLE
Document new feature for `yarn bin <executable>`

### DIFF
--- a/lang/en/docs/cli/bin.md
+++ b/lang/en/docs/cli/bin.md
@@ -8,6 +8,22 @@ layout: guide
 
 Displays the location of the yarn `bin` folder.
 
-##### `yarn bin` <a class="toc" id="toc-yarn-bin" href="#toc-yarn-bin"></a>
+##### `yarn bin [<executable>]` <a class="toc" id="toc-yarn-bin" href="#toc-yarn-bin"></a>
 
-`yarn bin` will print the folder where yarn will install executable files for your package. An example of an executable may be a script that you have defined for your package that can be executed via [`yarn run`]({{url_base}}/docs/cli/run).
+- `yarn bin` will print the folder where yarn will install executable files for your package. An example of an executable may be a script that you have defined for your package that can be executed via [`yarn run`]({{url_base}}/docs/cli/run).
+
+Example:
+
+```sh
+$ yarn bin
+/home/emillumine/Code/Funkwhale/funkwhale/front/node_modules/.bin
+```
+
+- `yarn bin <executable>` will print the path to the executable file.
+
+Example:
+
+```sh
+$ yarn bin gettext-compile
+/home/emillumine/Code/Funkwhale/funkwhale/front/node_modules/.bin/gettext-compile
+```


### PR DESCRIPTION
We add documentation for the new feature added in this commit: https://github.com/yarnpkg/yarn/commit/12d8f7fab0875af1e05a91dd5945e05c5350a6d1