### PR TITLE
Added jsDelivr hits to package details

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -365,6 +365,7 @@ script:
     github_stargazers: GitHub stargazers
     gitlab_stargazers: GitLab stargazers
     downloads_last_30_days: Downloads last 30 days
+    jsdelivr_hits: JsDelivr hits
     dependents: Dependents
     usage: Usage
     dependencies: Dependencies

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -365,7 +365,7 @@ script:
     github_stargazers: GitHub stargazers
     gitlab_stargazers: GitLab stargazers
     downloads_last_30_days: Downloads last 30 days
-    jsdelivr_hits: JsDelivr hits
+    jsdelivr_hits: jsDelivr last 30 days
     dependents: Dependents
     usage: Usage
     dependencies: Dependencies

--- a/js/src/lib/Details/Aside.js
+++ b/js/src/lib/Details/Aside.js
@@ -30,6 +30,7 @@ const Aside = ({
   devDependencies,
   bundlesize,
   onOpenFileBrowser,
+  jsDelivrHits,
 }) => (
   <aside className="details-side col-lg-4">
     <article className="details-side--links">
@@ -45,6 +46,7 @@ const Aside = ({
       dependents={dependents}
       humanDependents={humanDependents}
       name={name}
+      jsDelivrHits={jsDelivrHits}
     />
     {repository &&
       isKnownRepositoryHost(repository.host) &&

--- a/js/src/lib/Details/Popularity.js
+++ b/js/src/lib/Details/Popularity.js
@@ -52,6 +52,28 @@ const Dependents = ({ dependents, humanDependents, name }) =>
     />
   );
 
+const formatHits = (hits) => {
+  if (hits >= 1e9) {
+    return (Math.round(hits / 1e7) / 100) + "B";
+  } else if (hits >= 1e6) {
+    return (Math.round(hits / 1e4) / 100) + "M";
+  } else if (hits >= 1000) {
+    return (Math.round(hits / 10) / 100) + "k";
+  }
+
+  return hits;
+};
+
+const JsDelivrHits = ({jsDelivrHits}) => (<Di
+  icon="dependents"
+  title={window.i18n.detail.jsdelivr_hits}
+  description={
+    <span title={jsDelivrHits.toLocaleString(window.i18n.active_language)}>
+      {formatHits(jsDelivrHits)}
+    </span>
+  }
+/>);
+
 class Popularity extends Component {
   render() {
     const {
@@ -62,9 +84,10 @@ class Popularity extends Component {
       humanDownloads,
       dependents,
       humanDependents,
+      jsDelivrHits
     } = this.props;
 
-    if (downloads >= 0 || dependents >= 0 || stargazers >= 0) {
+    if (downloads >= 0 || dependents >= 0 || stargazers >= 0 || jsDelivrHits >= 0) {
       return (
         <article className="details-side--popularity">
           <h1>{window.i18n.detail.popularity}</h1>
@@ -76,6 +99,7 @@ class Popularity extends Component {
               humanDependents={humanDependents}
               name={name}
             />
+            <JsDelivrHits jsDelivrHits={jsDelivrHits} />
           </dl>
         </article>
       );

--- a/js/src/lib/Details/Popularity.js
+++ b/js/src/lib/Details/Popularity.js
@@ -65,7 +65,7 @@ const formatHits = (hits) => {
 };
 
 const JsDelivrHits = ({jsDelivrHits}) => (<Di
-  icon="dependents"
+  icon="downloads"
   title={window.i18n.detail.jsdelivr_hits}
   description={
     <span title={jsDelivrHits.toLocaleString(window.i18n.active_language)}>

--- a/js/src/lib/Details/Popularity.js
+++ b/js/src/lib/Details/Popularity.js
@@ -94,12 +94,12 @@ class Popularity extends Component {
           <dl>
             <Stargazers repository={repository} stargazers={stargazers} />
             <Downloads downloads={downloads} humanDownloads={humanDownloads} />
+            <JsDelivrHits jsDelivrHits={jsDelivrHits} />
             <Dependents
               dependents={dependents}
               humanDependents={humanDependents}
               name={name}
             />
-            <JsDelivrHits jsDelivrHits={jsDelivrHits} />
           </dl>
         </article>
       );

--- a/js/src/lib/Details/Popularity.js
+++ b/js/src/lib/Details/Popularity.js
@@ -54,9 +54,9 @@ const Dependents = ({ dependents, humanDependents, name }) =>
 
 const formatHits = (hits) => {
   if (hits >= 1e9) {
-    return (Math.round(hits / 1e7) / 100) + "B";
+    return (Math.round(hits / 1e7) / 100) + "b";
   } else if (hits >= 1e6) {
-    return (Math.round(hits / 1e4) / 100) + "M";
+    return (Math.round(hits / 1e4) / 100) + "m";
   } else if (hits >= 1000) {
     return (Math.round(hits / 10) / 100) + "k";
   }

--- a/js/src/lib/Details/index.js
+++ b/js/src/lib/Details/index.js
@@ -391,6 +391,7 @@ class Details extends Component {
         tags={this.state.tags}
         bundlesize={this.state.bundlesize}
         onOpenFileBrowser={this._openFileBrowser}
+        jsDelivrHits={this.state.jsDelivrHits}
       />
     );
   }

--- a/js/src/lib/schema.js
+++ b/js/src/lib/schema.js
@@ -9,6 +9,7 @@ export default {
   description: '…',
   downloadsLast30Days: 0,
   downloadsRatio: 0,
+  jsDelivrHits: 0,
   github: {
     stargazers_count: 0,
   },


### PR DESCRIPTION
Algolia provides jsDelivr hits in it's API, since the data are already there they only need to be displayed in package details.