### PR TITLE
How to add the install directory to PATH

### DIFF
--- a/lang/en/docs/cli/global.md
+++ b/lang/en/docs/cli/global.md
@@ -30,6 +30,15 @@ $ create-react-app
 
 `yarn global dir` will print the output of the global installation folder that houses the global `node_modules`. By default that will be: `~/.config/yarn/global`.
 
+### Adding the install location to your PATH
+
+To use the installed packages, the install location has to be added to the PATH environment variable of your shell.
+For bash for example, you can add this line at the end of your .bashrc:
+
+```sh
+export PATH="$(yarn global bin):$PATH"
+```
+
 Read more about the commands that can be used together with `yarn global`:
 
 - [`yarn add`]({{url_base}}/docs/cli/add): add a package to use in your current package.


### PR DESCRIPTION
The install directory is not added to the PATH automatically, so it would be nice to let the users know, they have to change that to be able to use the globally installed packages.
See: https://github.com/yarnpkg/yarn/issues/5353