### PR TITLE
Added back the user header for bundlephobia

### DIFF
--- a/js/src/lib/Details/index.js
+++ b/js/src/lib/Details/index.js
@@ -253,6 +253,9 @@ class Details extends Component {
     get({
       url: `https://bundlephobia.com/api/size?package=${name}@${version}`,
       type: 'json',
+      headers: {	
+        'X-Bundlephobia-User': 'yarn website',	
+      },
     }).then(res =>
       this.setState({
         bundlesize: {


### PR DESCRIPTION
Hi @Haroenv . I'm guessing this header might have been removed because of CORS issues in the past. These have been fixed now. In the absence of an API key, this header is required to recognise the source of traffic. It would be great if we can put this back.