### PR TITLE
Clarify when yarn.lock is or isn't updated

### DIFF
--- a/lang/en/docs/cli/install.md
+++ b/lang/en/docs/cli/install.md
@@ -25,6 +25,13 @@ If you need reproducible dependencies, which is usually the case with the contin
 Install all the dependencies listed within `package.json` in the local
 `node_modules` folder.
 
+The `yarn.lock` file is utilized as follows:
+
+- If `yarn.lock` is present and is enough to satisfy all the dependencies listed in `package.json`, the exact versions recorded in `yarn.lock` are installed, and `yarn.lock` will be unchanged. Yarn will not check for newer versions.
+- If `yarn.lock` is absent, or is _not_ enough to satisfy all the dependencies listed in `package.json` (for example, if you manually add a dependency to `package.json`), Yarn looks for the newest versions available that satisfy the constraints in `package.json`. The results are written to `yarn.lock`.
+
+If you want to ensure `yarn.lock` is not updated, use `--frozen-lockfile`.
+
 ##### `yarn install --check-files` <a class="toc" id="toc-yarn-install-check-files" href="#toc-yarn-install-check-files"></a>
 
 Verifies that already installed files in `node_modules` did not get removed.


### PR DESCRIPTION
Based on a conversation on this Twitter thread: https://twitter.com/arcanis/status/1063043732356898816

This clarifies the difference between when a bare `yarn install` uses `yarn.lock` and when it *updates* `yarn.lock`

I looked into making a change at https://yarnpkg.com/en/docs/installing-dependencies#toc-installing-dependencies but it seemed like that was too much to add for that introductory page. Linking to the `yarn install` page seemed sufficient for folks to dig into more detail and learn about these scenarios.