### PR TITLE
Update docs or issue on yarn workspaces?

### DIFF
--- a/lang/en/docs/workspaces.md
+++ b/lang/en/docs/workspaces.md
@@ -69,6 +69,7 @@ Finally, run `yarn install` somewhere, ideally inside the workspace root. If eve
 /node_modules
 /node_modules/cross-env
 /node_modules/workspace-a -> /workspace-a
+/node_modules/workspace-b -> /workspace-b
 
 /workspace-a/package.json
 /workspace-b/package.json


### PR DESCRIPTION
Tried the above example locally with `yarn v1.13.0`.
In the root folder as expected `/node_modules/workspace-a` is added, which is a dependency on `workspace-b`,.
Is it reasonable to also have `/node_modules/workspace-b` even if it is not a dependency in any workspace?