### PR TITLE
docs: Improve "install location to PATH" method

### DIFF
--- a/lang/en/docs/cli/global.md
+++ b/lang/en/docs/cli/global.md
@@ -33,10 +33,10 @@ $ create-react-app
 ### Adding the install location to your PATH
 
 To use the installed packages, the install location has to be added to the PATH environment variable of your shell.
-For bash for example, you can add this line at the end of your .bashrc:
+For bash for example, assuming the install location is `~/.yarn/bin`, you can add this line at the end of your .bashrc:
 
 ```sh
-export PATH="$(yarn global bin):$PATH"
+export PATH="$HOME/.yarn/bin:$PATH"
 ```
 
 Read more about the commands that can be used together with `yarn global`:


### PR DESCRIPTION
Right now, the docs on how to add the install location to PATH recommend appending the following command to your .bashrc: `export PATH="$(yarn global bin):$PATH"`

This solution certainly works, however it is inefficient and adds a considerable amount of start-up time to the shell, considering will evaluate `yarn global bin` every time the shell is opened. Since the output of this command is not expected to change, it's unnecessary to evaluate it every time.

Therefore, I edited the docs to change the command to `export PATH="$HOME/.yarn/bin:$PATH"` instead, namely, the default install location—of course they can change the command accordingly, if they set a different install location. This drastically reduces the shell start-up time compared to the other approach.