### PR TITLE
Remove outdated reference to --without-node argument

### DIFF
--- a/lang/en/docs/_installations/mac.md
+++ b/lang/en/docs/_installations/mac.md
@@ -8,10 +8,10 @@ This will also install Node.js if it is not already installed.
 brew install yarn
 ```
 
-If you use [nvm](https://github.com/creationix/nvm) or similar, you should exclude installing Node.js so that nvm's version of Node.js is used.
+If you use [nvm](https://github.com/creationix/nvm) or similar, you can exclude installing Node.js so that nvm's version of Node.js is used by ignoring dependencies.
 
 ```sh
-brew install yarn --without-node
+brew install yarn --ignore-dependencies
 ```
 
 #### MacPorts


### PR DESCRIPTION
Homebrew/homebrew-core#36222 removed support for passing arguments to `brew install yarn`. As such, we can no longer specify the `--without-node` option.