### PR TITLE
fix (styling): add newline around md code block

### DIFF
--- a/lang/en/docs/_installations/alternatives.md
+++ b/lang/en/docs/_installations/alternatives.md
@@ -26,14 +26,18 @@ if you already have it installed. If you already have
 Once you have npm installed you can run:
 
   <div class="install-only-stable" markdown="1">
+  
     ```sh
     npm install --global yarn
     ```
+  
   </div>
   <div class="install-only-rc" markdown="1">
+  
     ```sh
     npm install --global yarn@rc
     ```
+  
   </div>
 </div>
 <div class="install-only-nightly" markdown="1">


### PR DESCRIPTION
Currently the markdown code tags are rendered. I think this is because of the missing lines before and after the code blocks:

![unbenannt](https://user-images.githubusercontent.com/2488563/52720846-b63d6980-2fa8-11e9-84f3-fdf6ed0012ed.PNG)

Please review, I haven't visually checked it.