### PR TITLE
Add --update-new to Semaphore instructions

### DIFF
--- a/lang/en/docs/_ci/semaphore.md
+++ b/lang/en/docs/_ci/semaphore.md
@@ -10,5 +10,5 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 # install-package is a tool for caching APT installations in Semaphore
 # defining a package version is optional
-install-package yarn=<version>
+install-package --update-new yarn=<version>
 ```


### PR DESCRIPTION
Adding `--update-new` ensures that the Semaphore build updates the package lists before attempting to install Yarn. Otherwise it may fail to install if the package list doesn't contain the version you're attempting to install.