### PR TITLE
Add Gentoo Linux install instructions

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -270,6 +270,7 @@ install_os_alpine: Alpine
 install_os_arch: Arch Linux
 install_os_centos: CentOS / Fedora / RHEL
 install_os_debian: Debian / Ubuntu
+install_os_gentoo: Gentoo Linux
 install_os_mac: macOS
 install_os_opensuse: openSUSE
 install_os_solus: Solus

--- a/_layouts/pages/install-ci.html
+++ b/_layouts/pages/install-ci.html
@@ -27,7 +27,7 @@ scripts:
   {% include_relative _ci/solano.md %}
 {% endcapture %}
 {% capture gitlab %}
-  {% capture exists %}{%file_exists _ci/gitlab.md%}{% endcapture %}
+  {% capture exists %}{% file_exists _ci/gitlab.md %}{% endcapture %}
   {% if exists == "true" %}
     {% include_relative _ci/gitlab.md %}
   {% endif %}

--- a/_layouts/pages/install.html
+++ b/_layouts/pages/install.html
@@ -8,6 +8,7 @@ operating_systems:
   - arch
   - centos
   - debian
+  - gentoo
   - mac
   - solus
   - windows
@@ -46,11 +47,14 @@ operating_systems:
 <div id="install-instructions">
   <div class="install-os-instructions">Loading...</div>
   {% for os in layout.operating_systems %}
-    {% capture info %}{% include_relative _installations/{{os}}.md %}{% endcapture %}
     <div id="{{os}}" class="install-os-instructions" style="display: none">
       {% capture os_i18n %}install_os_{{os}}{% endcapture %}
       <h3>{{i18n[os_i18n]}}</h3>
-      {{info | markdownify}}
+      {% capture exists %}{% file_exists _installations/{{os}}.md %}{% endcapture %}
+      {% if exists == "true" %}
+        {% capture info %}{% include_relative _installations/{{os}}.md %}{% endcapture %}
+        {{info | markdownify}}
+      {% endif %}
     </div>
   {% endfor %}
 </div>

--- a/_plugins/file_exists.rb
+++ b/_plugins/file_exists.rb
@@ -14,7 +14,7 @@ module Jekyll
           # Adds the site source, so that it also works with a custom one
           site_source = context.registers[:site].config['source']
           dir_name = File.dirname(context.environments.first["page"]["path"])
-          file_path = File.join(site_source, dir_name, url)
+          file_path = File.join(site_source, dir_name, url.strip)
 
           # Check if file exists (returns true or false)
           "#{File.exist?(file_path)}"

--- a/lang/en/docs/_installations/gentoo.md
+++ b/lang/en/docs/_installations/gentoo.md
@@ -1,0 +1,16 @@
+<div class="install-only-stable" markdown="1">
+On Gentoo Linux, you can install Yarn with portage.
+```sh
+sudo emerge --ask sys-apps/yarn
+```
+</div>
+
+<div class="install-only-rc install-only-nightly" markdown="1">
+Currently, there are no Gentoo packages available for RC or nightly builds of Yarn. Please use the tarball:
+{% include_relative _installations/tarball.md %}
+</div>
+
+### Path Setup
+
+<!-- prettier-ignore -->
+{% include_relative _installations/unix_path_setup.md %}


### PR DESCRIPTION
Yarn is available on Gentoo's portage package manager (1), and I
have a pending patch to yarn to provide correct install instructions
from within the yarn cli (2).

(1) https://packages.gentoo.org/packages/sys-apps/yarn
(2) https://github.com/yarnpkg/yarn/pull/7123