### PR TITLE
add prepare on certain script names.

### DIFF
--- a/lang/en/docs/package-json.md
+++ b/lang/en/docs/package-json.md
@@ -270,7 +270,7 @@ Your package can include runnable scripts or other configuration.
 
 Scripts are a great way of automating tasks related to your package, such as simple build processes or development tools. Using the `"scripts"` field, you can define various scripts to be run as `yarn run <script>`. For example, the `build-project` script above can be invoked with `yarn run build-project` and will run `node build-project.js`.
 
-Certain script names are special. If defined, the `preinstall` script is called by yarn before your package is installed. For compatibility reasons, scripts called `install`, `postinstall`, and `prepublish` will all be called after your package has finished installing.
+Certain script names are special. If defined, the `preinstall` script is called by yarn before your package is installed. For compatibility reasons, scripts called `install`, `postinstall`, `prepublish`, and `prepare` will all be called after your package has finished installing.
 
 The `start` script value defaults to `node server.js`.
 


### PR DESCRIPTION
I notice that `prepare` was certain script names. 

https://github.com/yarnpkg/yarn/blob/8a671f10c86b66baa74ef6f4cd24d4ca8ee5067a/src/cli/commands/install.js#L1200