### PR TITLE
Add doc for `install --link-duplicates`.

### DIFF
--- a/lang/en/docs/cli/install.md
+++ b/lang/en/docs/cli/install.md
@@ -128,3 +128,7 @@ Checks for known security issues with the installed packages. A count of found i
 ##### `yarn install --no-bin-links` <a class="toc" id="toc-yarn-install-no-bin-links" href="#toc-yarn-install-no-bin-links"></a>
 
 Prevent yarn from creating symlinks for any binaries the package might contain.
+
+##### `yarn install --link-duplicates` <a class="toc" id="toc-yarn-install-link-duplicates" href="#toc-yarn-install-link-duplicates"></a>
+
+Create hardlinks to the repeated modules in node_modules.


### PR DESCRIPTION
`yarn install --link-duplicates` is not documented in the website.

This PR adds documentation for `install --link-duplicates`. The description is copied from https://github.com/yarnpkg/yarn/blob/bba4dce9018e4fa4ee38b78a5270e72187740d8b/src/cli/index.js#L94.