### PR TITLE
Update to lang/en/docs/migrating-from-npm.md

### DIFF
--- a/lang/en/docs/migrating-from-npm.md
+++ b/lang/en/docs/migrating-from-npm.md
@@ -58,7 +58,7 @@ your existing `npm-shrinkwrap.json` file and check in the newly created `yarn.lo
 | `npm rebuild`                           | `yarn add --force`                        |
 | `npm uninstall [package]`               | `yarn remove [package]`                   |
 | `npm cache clean`                       | `yarn cache clean [package]`              |
-| `rm -rf node_modules && npm install`    | `yarn upgrade`                            |
+| `npm ci`                                | `yarn upgrade`                            |
 | `npm version major`                     | `yarn version --major`                    |
 | `npm version minor`                     | `yarn version --minor`                    |
 | `npm version patch`                     | `yarn version --patch`                    |


### PR DESCRIPTION
`rm -rf node_modules && npm install` is the same as doing `npm ci`.

https://docs.npmjs.com/cli/ci