### PR TITLE
docs: add workspaces caveat note

### DIFF
--- a/lang/en/docs/workspaces.md
+++ b/lang/en/docs/workspaces.md
@@ -106,6 +106,8 @@ Yarn's workspaces are the low-level primitives that tools like Lerna can (and [d
 
 - In the example above, if `workspace-b` depends on a different version than the one referenced in `workspace-a`'s package.json, the dependency will be installed from npm rather than linked from your local filesystem. This is because some packages actually need to use the previous versions in order to build the new ones (Babel is one of them).
 
+  - NOTE: Workspaces will always use the local version if the dependency semver range matches the local version. However when you call `yarn version` (or `publish`) the workspace version might stop matching the range, which then will have to be manually updated
+
 - Be careful when publishing packages in a workspace. If you are preparing your next release and you decided to use a new dependency but forgot to declare it in the `package.json` file, your tests might still pass locally if another package already downloaded that dependency into the workspace root. However, it will be broken for consumers that pull it from a registry, since the dependency list is now incomplete so they have no way to download the new dependency. Currently there is no way to throw a warning in this scenario.
 
 - Workspaces must be descendants of the workspace root in terms of folder hierarchy. You cannot and must not reference a workspace that is located outside of this filesystem hierarchy.


### PR DESCRIPTION
## Description

Added note regarding Workspaces using local dependencies if available rather than reaching for the registry. This addition was prompted by [a tweet](https://twitter.com/arcanis/status/1136385324161097730?s=20) from @arcanis as I believe it is a bit easier to understand relative to the existing mention of this caveat.

Additional note added as a nested list item under the existing mention. I've transcribed the tweet to fit in the context, however I would appreciate any feedback you may have.