### PR TITLE
Document `link:` dependency type (#793)

### DIFF
--- a/lang/en/docs/cli/add.md
+++ b/lang/en/docs/cli/add.md
@@ -44,10 +44,13 @@ You can also specify packages from different locations:
     haven't been published to the registry.
 3.  `yarn add file:/path/to/local/tarball.tgz` installs a package from a gzipped
     tarball which could be used to share a package before publishing it.
-4.  `yarn add <git remote url>` installs a package from a remote git repository.
-5.  `yarn add <git remote url>#<branch/commit/tag>` installs a package from a remote
+4.  `yarn add link:/path/to/local/folder` installs a symlink to a package that is
+    on your local file system. This is useful to develop related packages in
+    monorepo environments.
+5.  `yarn add <git remote url>` installs a package from a remote git repository.
+6.  `yarn add <git remote url>#<branch/commit/tag>` installs a package from a remote
     git repository at specific git branch, git commit or git tag.
-6.  `yarn add https://my-project.org/package.tgz` installs a package from a
+7.  `yarn add https://my-project.org/package.tgz` installs a package from a
     remote gzipped tarball.
 
 ### Caveats <a class="toc" id="toc-caveats" href="#toc-caveats"></a>


### PR DESCRIPTION
This PR adds minimal documentation of the `link:` dependency type. The corresponding RFC is [0000-link-dependency-type](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-link-dependency-type.md) which has been merged in this PR: https://github.com/yarnpkg/rfcs/pull/34. The original implementation has been merged to yarn two years ago: https://github.com/yarnpkg/yarn/pull/3359.

The comment by @Haroenv on #793 suggested to put the documentation to https://github.com/yarnpkg/website/blob/master/lang/en/docs/package-json.md, but since there's no existing documentation of other dependency types like `file:` on that page, I decided to go the minimal route and just update the documentation of `yarn add` which already has several examples. I can update package-json docs in this or followup PR if we'd like to have this information in that page too.