### PR TITLE
Adding yarn update info to docs

### DIFF
--- a/lang/en/docs/cli/self-update.md
+++ b/lang/en/docs/cli/self-update.md
@@ -9,3 +9,5 @@ layout: guide
 ##### `yarn self-update` <a class="toc" id="toc-yarn-self-update" href="#toc-yarn-self-update"></a>
 
 _Note: `self-update` is not available. See [policies](https://yarnpkg.com/lang/en/docs/cli/policies/#toc-policies-set-version) for enforcing versions within a project_
+
+In order to update your version of Yarn, run `curl --compressed -o- -L https://yarnpkg.com/install.sh | bash`


### PR DESCRIPTION
`yarn install` helpfully says
```
warning Your current version of Yarn is out of date. The latest version is "1.16.0", while you're on "1.15.2".
info To upgrade, run the following command:
$ curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
```
Yet when looking at the self-update documentation it doesn't actually tell you how to update yarn.