### PR TITLE
Improve output of install script when using fish

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,14 +94,15 @@ yarn_link() {
     if ! grep -q 'yarn' "$YARN_PROFILE"; then
       if [[ $YARN_PROFILE == *"fish"* ]]; then
         command fish -c 'set -U fish_user_paths $fish_user_paths ~/.yarn/bin'
+        printf "$cyan> We've added ~/.yarn/bin to your fish_user_paths universal variable\n"
       else
         command printf "$SOURCE_STR" >> "$YARN_PROFILE"
+        printf "$cyan> We've added the following to your $YARN_PROFILE\n"
       fi
+      
+      echo "> If this isn't the profile of your current shell then please add the following to your correct profile:"
+      printf "   $SOURCE_STR$reset\n"
     fi
-
-    printf "$cyan> We've added the following to your $YARN_PROFILE\n"
-    echo "> If this isn't the profile of your current shell then please add the following to your correct profile:"
-    printf "   $SOURCE_STR$reset\n"
 
     version=`$HOME/.yarn/bin/yarn --version` || (
       printf "$red> Yarn was installed, but doesn't seem to be working :(.$reset\n"


### PR DESCRIPTION
When adding `~/.yarn/bin` to `fish_user_paths` the output message was inaccurate. This also means that "Please open another terminal where the `yarn` command will now be available." is not accurate (it will be available immediately), although I am unsure of the best way to structure the code to alter this output.