### PR TITLE
link to CHANGELOG from stable version link

### DIFF
--- a/_includes/version.html
+++ b/_includes/version.html
@@ -2,7 +2,7 @@
   <div>
     {{i18n.site_nav_stable_version}}:
     <strong class="navbar-text">
-      <a href="https://github.com/yarnpkg/yarn/releases/tag/v{{site.latest_version}}">
+      <a href="https://github.com/yarnpkg/yarn/blob/master/CHANGELOG.md">
         v{{site.latest_version}}
       </a>
     </strong>


### PR DESCRIPTION
Since the release notes are no longer under the releases, I think it's much more helpful to see the release notes when clicking on the stable version. I'm not sure if it's worth it to add the fragment to the url with the current version since you'd have to change `1.17.3` to `1170` for example - not sure how consistent that's guaranteed to be.