### PR TITLE
Fix Singapore Chinese language code

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -133,8 +133,8 @@
 - name: 中文
   tag: zh-Hans
   enabled: Yes
-  accept_languages: ["zh-cn"]
+  accept_languages: ["zh-cn", "zh-sg"]
 - name: 繁體中文
   tag: zh-Hant
   enabled: Yes
-  accept_languages: ["zh-hk", "zh-tw", "zh-sg"]
+  accept_languages: ["zh-hk", "zh-tw"]


### PR DESCRIPTION
This change moves `zh-sg` from under `zh-Hant` to under `zh-Hans`

Rationale: Singapore has switched to using the Simplified variant of the Chinese language since 1969