### PR TITLE
docs(readme): Add deployment badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Yarn Website
-[![Netlify](https://img.shields.io/badge/netlify-automated-informational?logo=netlify)](https://app.netlify.com/sites/yarnpkg/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/85057564-01fa-49d4-b898-30acb74ae19e/deploy-status)](https://app.netlify.com/sites/yarnpkg/deploys)
 ============
 
 This repo contains the source code for the Yarn website.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Yarn Website
+Yarn Website
+[![Netlify](https://img.shields.io/badge/netlify-automated-informational?logo=netlify)](https://app.netlify.com/sites/yarnpkg/deploys)
+============
 
 This repo contains the source code for the Yarn website.
 


### PR DESCRIPTION
This adds a [Shields.io](https://shields.io) static deployment badge to README.md.

Note that Netlify now supports [status badges](https://www.netlify.com/docs/continuous-deployment/#status-badges), but those [use a UUID as the identifier](https://www.netlify.com/blog/2019/01/29/sharing-the-love-with-netlify-deployment-badges/#how-to-add-a-deployment-badge), which means that it has to be added by someone with access to the Netlify settings page.