### PR TITLE
jest -> test

### DIFF
--- a/lang/en/docs/cli/run.md
+++ b/lang/en/docs/cli/run.md
@@ -39,7 +39,7 @@ You can pass additional arguments to your script by passing them after the scrip
 yarn run test -o --watch
 ```
 
-Running this command will execute `jest -o --watch`.
+Running this command will execute `test -o --watch`.
 
 `[script]` can also be any locally installed executable that is inside `node_modules/.bin/`.
 


### PR DESCRIPTION
Fixes a spelling mistake. `jest` should have been `test`.