### PR TITLE
Remove outdated Travis CI container setup

### DIFF
--- a/lang/en/docs/_ci/travis.md
+++ b/lang/en/docs/_ci/travis.md
@@ -3,14 +3,7 @@ If it is available, Travis CI will install `yarn` if necessary, and execute `yar
 
 If your install phase requires more, it is necessary to install Yarn yourself until it is pre-installed on build images.
 
-There are a couple of ways to install Yarn; one with `sudo`, the other without.
-If you are using the [container-based environment](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments)
-use the latter.
-
-## `sudo`-enabled builds
-
 ```yml
-sudo: required
 before_install: # if "install" is overridden
   # Repo for Yarn
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
@@ -23,17 +16,3 @@ cache:
 
 <!-- prettier-ignore -->
 {% include_relative _ci/deb-specific-version.md %}
-
-## container-based builds
-
-Container-based builds do not have the `sudo` privilege, so they must rely on other means to install.
-For example:
-
-```yaml
-sudo: false
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version {{site.latest_version}}
-  - export PATH=$HOME/.yarn/bin:$PATH
-cache:
-  yarn: true
-```


### PR DESCRIPTION
Travis CI no longer offers a container-based infrastructure, which makes virtual machines with `sudo` the only option. See [The Container-Based Build Environment is Fully Deprecated](https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517).