### PR TITLE
Make PATH check stricter in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ yarn_link() {
     printf "> Append the following lines to the correct file yourself:$reset\n"
     command printf "${SOURCE_STR}"
   else
-    if ! grep -q 'yarn' "$YARN_PROFILE"; then
+    if ! grep -q 'yarn/bin' "$YARN_PROFILE"; then
       if [[ $YARN_PROFILE == *"fish"* ]]; then
         command fish -c 'set -U fish_user_paths $fish_user_paths ~/.yarn/bin'
         printf "$cyan> We've added ~/.yarn/bin to your fish_user_paths universal variable\n"


### PR DESCRIPTION
After installing yarn, the install.sh script updates the PATH variable in the user's shell profile. Before updating, it checks whether the profile already contains the PATH declaration to skip adding it redundantly. This check is done by searching for 'yarn' anywhere in the shell config, which can lead to false positives in some oh-my-zsh configs such as `plugins=(... yarn)`, leaving the installation unlinked.

This PR makes the check stricter by looking for 'yarn/bin', which is less likely to occur in any context different than a PATH declaration.
