### PR TITLE
change apt-get to apt in debian installation

### DIFF
--- a/lang/en/docs/_installations/debian.md
+++ b/lang/en/docs/_installations/debian.md
@@ -25,7 +25,7 @@ On Ubuntu 16.04 or below and Debian Stable, you will also need to configure [the
 Then you can simply:
 
 ```sh
-sudo apt-get update && sudo apt-get install yarn
+sudo apt update && sudo apt install yarn
 ```
 
 **Note**: Ubuntu 17.04 comes with `cmdtest` installed by default. If you're getting errors from installing `yarn`, you may want to run `sudo apt remove cmdtest` first. Refer to [this](https://github.com/yarnpkg/yarn/issues/2821) for more information.
@@ -33,7 +33,7 @@ sudo apt-get update && sudo apt-get install yarn
 If using `nvm` you can avoid the `node` installation by doing:
 
 ```sh
-sudo apt-get update && sudo apt-get install --no-install-recommends yarn
+sudo apt update && sudo apt install --no-install-recommends yarn
 ```
 
 **Note**: Due to the use of `nodejs` instead of `node` name in some distros, `yarn` might complain about `node` not being installed. A workaround for this is to add an alias in your `.bashrc` file, like so: `alias node=nodejs`. This will point `yarn` to whatever version of `node` you decide to use.

--- a/lang/en/docs/_installations/nightly.md
+++ b/lang/en/docs/_installations/nightly.md
@@ -11,7 +11,7 @@ An Ubuntu/Debian repository of the nightly builds is also available. To enable i
 ```sh
 sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 echo "deb http://nightly.yarnpkg.com/debian/ nightly main" | sudo tee /etc/apt/sources.list.d/yarn-nightly.list
-sudo apt-get update && sudo apt-get install yarn
+sudo apt update && sudo apt install yarn
 ```
 
 On Windows, the [Windows installer](https://nightly.yarnpkg.com/latest.msi) can be used.


### PR DESCRIPTION
In #968 @Daniel15 mentions `apt-get` should be updated to `apt` instead. I changed this in the debian install and nightly install instructions. 

The CI install docs for travis still have `apt-get` (see https://yarnpkg.com/lang/en/docs/install-ci/) I can also change those, but I believe `apt-get` is still preferred in scripts? 