### PR TITLE
install.sh: Post-verification cleanup (terminate gpg-agent)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,14 +62,14 @@ yarn_verify_integrity() {
   printf "$cyan> Verifying integrity...$reset\n"
 
   # Check whether a gpg-agent process already exists for this session
-  existing_gpg_agent=$(pgrep gpg-agent || echo)
+  existing_gpg_agent=$(pgrep gpg-agent || pidof gpg-agent || echo)
 
   # Grab the public key if it doesn't already exist
   gpg --list-keys $gpg_key >/dev/null 2>&1 || (curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import)
 
   # If no gpg-agent process was running previously, terminate any that may have been created during key import
   if [ -z ${existing_gpg_agent} ]; then
-    pkill gpg-agent || true
+    gpgconf --kill gpg-agent
   fi
 
   if [ ! -f "$1.asc" ]; then

--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,9 @@ yarn_verify_integrity() {
     printf "$red> GPG signature for this Yarn release is invalid! This is BAD and may mean the release has been tampered with. It is strongly recommended that you report this to the Yarn developers.$reset\n"
     yarn_verify_or_quit "> Do you really want to continue?"
   fi
+
+  # Cleanup verification resources
+  yarn_verification_cleanup
 }
 
 yarn_link() {
@@ -205,12 +208,17 @@ yarn_install() {
   yarn_reset
 }
 
+yarn_verification_cleanup() {
+  gpgconf --kill gpg-agent
+}
+
 yarn_verify_or_quit() {
   read -p "$1 [y/N] " -n 1 -r
   echo
   if [[ ! $REPLY =~ ^[Yy]$ ]]
   then
     printf "$red> Aborting$reset\n"
+    yarn_verification_cleanup
     exit 1
   fi
 }

--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ yarn_verify_integrity() {
 
   # If no gpg-agent process was running previously, terminate any that may have been created during key import
   if [ -z ${existing_gpg_agent} ]; then
-    gpgconf --kill gpg-agent
+    gpgconf --kill gpg-agent || echo "Warning: Failed to perform gpg-agent cleanup; is gpgconf installed?" 2>&1
   fi
 
   if [ ! -f "$1.asc" ]; then

--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ yarn_verify_integrity() {
 
   # If no gpg-agent process was running previously, terminate any that may have been created during key import
   if [ -z ${existing_gpg_agent} ]; then
-    gpgconf --kill gpg-agent
+    pkill gpg-agent || true
   fi
 
   if [ ! -f "$1.asc" ]; then


### PR DESCRIPTION
This changeset terminates any `gpg-agent` processes created as side-effects during the `install.sh` script.

If _existing_ `gpg-agent` processes were found before GPG functionality is invoked in the script, those existing processes will be left untouched so as not to affect unrelated system/user functionality.

Fixes #1029