### PR TITLE
Add mention to ignore .pnp.* files

### DIFF
--- a/lang/en/docs/pnp/getting-started.md
+++ b/lang/en/docs/pnp/getting-started.md
@@ -18,6 +18,8 @@ Getting started with Plug'n'Play isn't difficult - at its basis it just involves
 
 From now on each time you'll run `yarn install` Yarn will create a single file named `.pnp.js` instead of the `node_modules` megafolder. You can try it right now by running `yarn --pnp` in your project, which will enable the settings and run the install in the same pass!
 
+`.pnp.*` should also be added to your `.gitignore`. (see [which files should get ignored](https://yarnpkg.com/advanced/qa#which-files-should-be-gitignored))
+
 So enabling PnP isn't complicated at all - what might be an issue are third-party packages that reimplement the Node resolution themselves. Three major implementations exist, more might also hide from a project to another:
 
 - [`resolve`](https://yarnpkg.com/en/package/resolve) is the main one, and is supported out-of-the-box thanks to the help of [Jordan Harband](https://github.com/ljharb). Every package using `resolve` (and that includes things you might have heard of like Babel or Gulp) now works without further configuration.


### PR DESCRIPTION
As as a user that is new to PnP but not to yarn who is looking to migrate an existing project, I felt confused about this point when using the getting started docs. I think it would be helpful to add here.