### PR TITLE
Fix typos across yarn website repo

### DIFF
--- a/_posts/2017-07-11-lets-dev-a-package-manager.md
+++ b/_posts/2017-07-11-lets-dev-a-package-manager.md
@@ -552,7 +552,7 @@ function optimizePackageTree({ name, reference, dependencies }) {
 
       // If we've adopted the sub-dependency, or if the already existing
       // dependency has the exact same reference than the sub-dependency,
-      // then it becames useless and we can simply delete it.
+      // then it becomes useless and we can simply delete it.
       if (
         !availableDependency ||
         availableDependency.reference === subDependency.reference

--- a/lang/en/docs/yarnrc.md
+++ b/lang/en/docs/yarnrc.md
@@ -56,7 +56,7 @@ Value must be a boolean, defaults to `false`.
 child-concurrency #number#
 ```
 
-Controls the number of child processes run parallely to build node modules.
+Controls the number of child processes run parallelly to build node modules.
 
 Setting this number to 1 will cause the node modules to be built sequentially which can avoid linker errors on windows with node-gyp.
 

--- a/lang/en/docs/yarnrc.md
+++ b/lang/en/docs/yarnrc.md
@@ -56,7 +56,7 @@ Value must be a boolean, defaults to `false`.
 child-concurrency #number#
 ```
 
-Controls the number of child processes run parallelly to build node modules.
+Controls the number of child processes that run in parallel to build node modules.
 
 Setting this number to 1 will cause the node modules to be built sequentially which can avoid linker errors on windows with node-gyp.
 

--- a/lang/en/package.html
+++ b/lang/en/package.html
@@ -4,7 +4,7 @@ scripts:
   - "/js/build/package.js"
 --- 
 {% comment %}
-this is the default package view to make the load percieve smoother, 
+this is the default package view to make the load perceive smoother, 
 for the implementation, look at /js/components/Details.js etc. 
 {% endcomment %}
 <div id="pkg-detail">


### PR DESCRIPTION
:writing_hand: **Fix typos across yarn website repo**

**Files that have typos**

```
website/_posts/2017-07-11-lets-dev-a-package-manager.md:555:17: "becames" is a misspelling of "becomes"
website/lang/en/docs/yarnrc.md:59:43: "parallely" is a misspelling of "parallelly"
website/lang/en/package.html:7:50: "percieve" is a misspelling of "perceive"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: 

Making the world a better place :innocent: