### PR TITLE
Chore: Update Lerna URL lernajs.io => lerna.js.org

### DIFF
--- a/_posts/2017-07-26-introducing-workspaces.md
+++ b/_posts/2017-07-26-introducing-workspaces.md
@@ -16,7 +16,7 @@ Those who have [tried splitting a project into multiple packages](https://youtu.
 
 Several projects used every day by JavaScript developers are managed as monorepos: [Babel](https://github.com/babel/babel/tree/master/packages), [React](https://github.com/facebook/react/tree/master/packages), [Jest](https://github.com/facebook/jest/tree/master/packages), [Vue](https://github.com/vuejs/vue/tree/dev/packages), [Angular](https://github.com/angular/angular/tree/master/packages).
 
-However, separating pieces of projects into their own folders is sometimes not enough. Testing, managing dependencies, and publishing multiple packages quickly gets complicated and many such projects [adopt](https://medium.com/@bebraw/the-case-for-monorepos-907c1361708a) tools such as [Lerna](https://lernajs.io/) to make working with monorepos easier.
+However, separating pieces of projects into their own folders is sometimes not enough. Testing, managing dependencies, and publishing multiple packages quickly gets complicated and many such projects [adopt](https://medium.com/@bebraw/the-case-for-monorepos-907c1361708a) tools such as [Lerna](https://lerna.js.org/) to make working with monorepos easier.
 
 ## Lerna
 


### PR DESCRIPTION
Hi there 👋  I noticed a small issue during my documentation travels.

The current URL (`https://lernajs.io/`) pointing to the _*Lerna*_ home page does not work 😢

It looks like the working URL should be changed to (`https://lerna.js.org/`) 🥳

---
## Before 👎

<img width="505" alt="Screen Shot 2020-03-16 at 9 08 35 PM" src="https://user-images.githubusercontent.com/15273233/76740747-3d27cb80-67d3-11ea-9daf-1aaa739c6cc8.png">


## After 👍

<img width="506" alt="Screen Shot 2020-03-16 at 9 08 16 PM" src="https://user-images.githubusercontent.com/15273233/76740755-4022bc00-67d3-11ea-93cc-de439a88c834.png">

---

Thanks!