### PR TITLE
Glob pattern negate flag is not supported in yarn

### DIFF
--- a/lang/en/docs/package-json.md
+++ b/lang/en/docs/package-json.md
@@ -201,7 +201,7 @@ You can specify files that will be included in your project, along with the main
 }
 ```
 
-These are files that are included in your project. You can specify single files, whole directories or use wildcards to include files that meet a certain criteria.
+These are files that are included in your project. You can specify single files, whole directories or use wildcards to include files that meet a certain criteria. The glob pattern negate flag is not supported in yarn.
 
 ### `main` <a class="toc" id="toc-main" href="#toc-main"></a>
 


### PR DESCRIPTION
The glob pattern negate flag in `package.json#files` is not supported in yarn, it is not written anywhere. Apparently it's an implementation choice through looking at `utils/filter.js` and `cli/pack.js` in yarn source and to implement the negate flag it seems like the entire `utils/filter.js` needs to be rewritten. 

I think it might be best to mention this in the docs.

https://github.com/yarnpkg/yarn/issues/7888
https://github.com/team-innovation/vue-sfc-rollup/issues/40
https://github.com/fuxingloh/yarn/commit/62b728226cb83ed064beeac7609a0e8ce083caa9