### PR TITLE
Update link.md

### DIFF
--- a/lang/en/docs/cli/link.md
+++ b/lang/en/docs/cli/link.md
@@ -47,7 +47,7 @@ success Registered "react".
 This will create a symlink named `react-relay/node_modules/react` that links to
 your local copy of the `react` project.
 
-Links are registered in `~/.config/yarn/link`.
+Links are registered in `~/.config/yarn/link`. If you want to specify a different folder you can run the command with this syntax `yarn link --link-folder path/to/dir/`
 
 To reverse this process, simply use `yarn unlink` or `yarn unlink [package]`. Also see:
 


### PR DESCRIPTION
Minor documentation change. It talks about the link folder option under yarn link. `yarn link --link-folder ~/.local/bin/`