### PR TITLE
Typo: "patching" -> "matching" in upgrade.md

### DIFF
--- a/lang/en/docs/cli/upgrade.md
+++ b/lang/en/docs/cli/upgrade.md
@@ -19,7 +19,7 @@ Optionally, one or more package names can be specified.
 When package names are specified, only those packages will be upgraded.
 When no package names are specified, all dependencies will be upgraded.
 
-`[package]` : When a specified package is only a name then the latest patching version
+`[package]` : When a specified package is only a name then the latest matching version
 of this package will be upgraded to.
 
 `[package@tag]` : When a specified package contains a tag then the specified tag will


### PR DESCRIPTION
This seems like a typo. I assume it means it will update to the latest version _matching_ the package.json.