### PR TITLE
Docs: Document the `--cwd` global option

### DIFF
--- a/lang/en/docs/cli/index.md
+++ b/lang/en/docs/cli/index.md
@@ -54,3 +54,9 @@ can also specify an alternate port.
 ## Verbose output with `--verbose` <a class="toc" id="toc-verbose" href="#toc-verbose"></a>
 
 Running `yarn <command> --verbose` will print verbose info for the execution (creating directories, copying files, HTTP requests, etc.).
+
+## Specify working directory with `yarn --cwd <command>` <a class="toc" id="toc-cwd" href="#toc-cwd"></a>
+
+Specifies a current working directory, instead of the default `./`. Use this flag to perform an operation in a working directory that is not the current one.
+
+This can make scripts nicer by avoiding the need to `cd` into a folder and then `cd` back out.


### PR DESCRIPTION
Closes #651

This is a copy of an existing PR (#774), moving the documentation added there into the index alongside other global options `--mutex` and `--verbose`.

It's been a while and this feature remains undocumented, which is a shame because it's a very useful one. This has also been discussed in the [issue](#651) and I think this PR provides a good solution.