### PR TITLE
Update cli index with note about terminal colors

### DIFF
--- a/lang/en/docs/cli/index.md
+++ b/lang/en/docs/cli/index.md
@@ -55,6 +55,10 @@ can also specify an alternate port.
 
 Running `yarn <command> --verbose` will print verbose info for the execution (creating directories, copying files, HTTP requests, etc.).
 
+## Force ANSI color output
+
+Yarn utilizes the [chalk](https://github.com/chalk/chalk) terminal colors library and will respect an environment variable setting `FORCE_COLOR=true`, e.g. to make script tasks output color when the terminal is not a tty (e.g., in CI environments.)
+
 ## Specify working directory with `yarn --cwd <command>` <a class="toc" id="toc-cwd" href="#toc-cwd"></a>
 
 Specifies a current working directory, instead of the default `./`. Use this flag to perform an operation in a working directory that is not the current one.


### PR DESCRIPTION
Fixes https://github.com/yarnpkg/yarn/issues/5733

By updating documentation :smile: 