### PR TITLE
docs: add update notices

### DIFF
--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -16,7 +16,7 @@ site_nav_blog: Blog
 site_nav_stable_version: Classic Stable
 site_nav_rc_version: Classic Release Candidate
 site_nav_nightly_version: Classic Nightly
-site_nav_node_support: Classic Node
+site_nav_node_support: Node
 
 site_bsd_license: Distributed under BSD License
 site_code_of_conduct: Code of Conduct

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -13,10 +13,10 @@ site_nav_getting_started: Getting Started
 site_nav_documentation: Docs
 site_nav_packages: Packages
 site_nav_blog: Blog
-site_nav_stable_version: Stable
-site_nav_rc_version: Release Candidate
-site_nav_nightly_version: Nightly
-site_nav_node_support: Node
+site_nav_stable_version: Classic Stable
+site_nav_rc_version: Classic Release Candidate
+site_nav_nightly_version: Classic Nightly
+site_nav_node_support: Classic Node
 
 site_bsd_license: Distributed under BSD License
 site_code_of_conduct: Code of Conduct

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -57,6 +57,7 @@ homepage_feature_reliable_image_alt: Watercolour of cat waving from seat behind 
 homepage_c2a_text: What are you waiting for?
 homepage_c2a_button: Get Started
 homepage_install_button: Install Yarn
+homepage_migrate_button: Migrate to Yarn 2+
 
 homepage_featurette_offline_title: Offline Mode
 homepage_featurette_offline_description: |

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -5,6 +5,10 @@
 site_title: Yarn
 site_description: Fast, reliable, and secure dependency management.
 
+site_news_important: Important
+site_news_docs_cover_v1: This documentation covers Yarn 1 (Classic).
+site_news_see_v2_docs: For Yarn 2+ docs and migration guide, see yarnpkg.com.
+
 site_nav_getting_started: Getting Started
 site_nav_documentation: Docs
 site_nav_packages: Packages

--- a/_data/i18n/en.yml
+++ b/_data/i18n/en.yml
@@ -267,7 +267,9 @@ users_add_requirements_logo: >
 
 install_intro: >
   Before you start using Yarn, you'll first need to install it on your system.
-  There are a growing number of different ways to install Yarn:
+  There are many different ways to install Yarn, but a single one is recommended and cross-platform:
+install_alternatives: Alternatives
+install_click_to_expand_collapse: Click to expand / collapse
 install_select_platform: Select your platform above
 install_os: Operating system
 install_version: Version
@@ -282,14 +284,8 @@ install_os_solus: Solus
 install_os_windows: Windows
 install_os_alternatives: Alternatives
 
-install_test: "Test that Yarn is installed by running:"
-
-install_problems_title: Problems?
-install_problems_description: >
-  If you are unable to install Yarn with any of these installers, please search
-  through GitHub for an existing issue or open a new one.
-install_problems_search: Search for an existing issue
-install_problems_new_issue: Open a new issue
+install_check: "Check installation"
+install_check_details: "Check that Yarn is installed by running:"
 
 docs_nightly: Nightly Builds
 install_nightly_intro: >

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -1,0 +1,14 @@
+{% include vars.html %}
+
+<div class="news-container">
+  <a class="news-overlay" href="https://yarnpkg.com/getting-started/migration"></a>
+
+  <div class="news-inner">
+    <div class="news-line">
+      <span class="news-highlight">{{i18n.site_news_important}}:</span> {{i18n.site_news_docs_cover_v1}}
+    </div>
+    <div class="news-line">
+      {{i18n.site_news_see_v2_docs}}
+    </div>
+  </div>
+</div>

--- a/_includes/version-with-upgrade-notice.html
+++ b/_includes/version-with-upgrade-notice.html
@@ -1,9 +1,12 @@
 <div class="alert alert-warning news-container-alert mt-4">
   <a class="news-overlay" href="https://yarnpkg.com/getting-started/migration#why-should-you-migrate"></a>
   <div class="news-inner">
-    These instructions only cover Yarn versions prior to 2.0. They entered <a href="https://en.wikipedia.org/wiki/Maintenance_mode">maintenance mode</a> in January 2020 and will eventually reach their end-of-life in terms of support. To see the up-to-date documentation, check the main website: <a href="https://yarnpkg.com/getting-started">yarnpkg.com/getting-started</a>.
-    <br>
-    The latest Yarn version is: <img alt="Latest CLI Release" src="https://img.shields.io/npm/v/@yarnpkg/cli/latest?label=latest">
+    <div>
+      These instructions only cover Yarn versions prior to 2.0. Those versions entered <a href="https://en.wikipedia.org/wiki/Maintenance_mode">maintenance mode</a> in January 2020 and will eventually reach their end-of-life in terms of support. Please see the main website for the most up-to-date documentation: <a href="https://yarnpkg.com/getting-started/migration#why-should-you-migrate">yarnpkg.com/getting-started/migration</a>.
+    </div>
+    <div style="margin-top: 15px">
+      The latest Yarn version is: <img alt="Latest CLI Release" src="https://img.shields.io/npm/v/@yarnpkg/cli/latest?label=latest">
+    </div>
   </div>
 </div>
 

--- a/_includes/version-with-upgrade-notice.html
+++ b/_includes/version-with-upgrade-notice.html
@@ -1,0 +1,10 @@
+<div class="alert alert-warning news-container-alert mt-4">
+  <a class="news-overlay" href="https://yarnpkg.com/getting-started/migration#why-should-you-migrate"></a>
+  <div class="news-inner">
+    These instructions only cover Yarn versions prior to 2.0. They entered <a href="https://en.wikipedia.org/wiki/Maintenance_mode">maintenance mode</a> in January 2020 and will eventually reach their end-of-life in terms of support. To see the up-to-date documentation, check the main website: <a href="https://yarnpkg.com/getting-started">yarnpkg.com/getting-started</a>.
+    <br>
+    The latest Yarn version is: <img alt="Latest CLI Release" src="https://img.shields.io/npm/v/@yarnpkg/cli/latest?label=latest">
+  </div>
+</div>
+
+{% include version.html %}

--- a/_includes/version.html
+++ b/_includes/version.html
@@ -17,7 +17,7 @@
     {% endif %}
   </div>
   <div>
-    {{i18n.site_nav_node_support}}: 
+    {{i18n.site_nav_node_support}}:
     <strong>
       {{site.node_support}}
     </strong>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,6 +33,7 @@
     {% include debug/url.html url=page.url %}
     {% include debug/todo.html content=page.content %}
 
+    {% include news.html %}
     {% include navigation.html %}
     <div id="search">
       <!-- Here to avoid flash of unstyled content on page load -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,6 +7,7 @@ layout: default
 <div class="hero">
   <div class="container">
     <h1 class="hero-text display-4">{{i18n[page.id]}}</h1>
+
     {% if layout.hero_subtext %}
       {% include {{ layout.hero_subtext }} %}
     {% elsif page.hero_subtext %}

--- a/_layouts/pages/homepage.html
+++ b/_layouts/pages/homepage.html
@@ -14,6 +14,7 @@ shitty: Yes
     <div>
       <a class="btn hero-btn hidden-md-down" href="{{url_base}}/docs/getting-started">{{i18n.homepage_c2a_button}}</a>
       <a class="btn hero-btn hidden-md-down" href="{{url_base}}/docs/install">{{i18n.homepage_install_button}}</a>
+      <a class="btn hero-btn hidden-md-down" href="https://yarnpkg.com/getting-started/migration">{{i18n.homepage_migrate_button}}</a>
 
       <span class="hero-ghbtn">
         <iframe src="https://ghbtns.com/github-btn.html?user=yarnpkg&repo=yarn&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px" title="{{i18n.iframe_github_stars}}"></iframe>

--- a/_layouts/pages/install.html
+++ b/_layouts/pages/install.html
@@ -19,48 +19,61 @@ operating_systems:
 
 {{i18n.install_intro}}
 
-<div class="install-select-os">
-  <div class="form-group row">
-    <label for="os" class="col-3 col-form-label">{{i18n.install_os}}:</label>
-    <div class="col-6">
-      <select id="os" class="form-control">
-        {% for os in layout.operating_systems %}
-          {% capture os_i18n %}install_os_{{os}}{% endcapture %}
-          <option value="{{os}}">{{i18n[os_i18n]}}</option>
-        {% endfor %}
-      </select>
+{% capture npm_info %}{% include_relative _installations/npm.md %}{% endcapture %}
+{{npm_info | markdownify}}
+
+<h2>{{i18n.install_alternatives}}</h2>
+
+<details>
+  <summary>{{i18n.install_click_to_expand_collapse}}</summary>
+
+  <br />
+
+  <div class="install-select-os">
+    <div class="form-group row">
+      <label for="os" class="col-3 col-form-label">{{i18n.install_os}}:</label>
+      <div class="col-6">
+        <select id="os" class="form-control">
+          {% for os in layout.operating_systems %}
+            {% capture os_i18n %}install_os_{{os}}{% endcapture %}
+            <option value="{{os}}">{{i18n[os_i18n]}}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <label for="version" class="col-3 col-form-label">{{i18n.install_version}}:</label>
+      <div class="col-6">
+        <select id="version" class="form-control">
+          <option value="stable">{{i18n.site_nav_stable_version}} ({{site.latest_version}})</option>
+          <option value="rc">{{i18n.site_nav_rc_version}} ({{site.latest_rc_version}})</option>
+          <option id="nightly-version" value="nightly">{{i18n.site_nav_nightly_version}}</option>
+        </select>
+      </div>
     </div>
   </div>
 
-  <div class="form-group row">
-    <label for="version" class="col-3 col-form-label">{{i18n.install_version}}:</label>
-    <div class="col-6">
-      <select id="version" class="form-control">
-        <option value="stable">{{i18n.site_nav_stable_version}} ({{site.latest_version}})</option>
-        <option value="rc">{{i18n.site_nav_rc_version}} ({{site.latest_rc_version}})</option>
-        <option id="nightly-version" value="nightly">{{i18n.site_nav_nightly_version}}</option>
-      </select>
-    </div>
+  <div id="install-instructions">
+    <div class="install-os-instructions">Loading...</div>
+    {% for os in layout.operating_systems %}
+      <div id="{{os}}" class="install-os-instructions" style="display: none">
+        {% capture os_i18n %}install_os_{{os}}{% endcapture %}
+        <h3>{{i18n[os_i18n]}}</h3>
+        {% capture exists %}{% file_exists _installations/{{os}}.md %}{% endcapture %}
+        {% if exists == "true" %}
+          {% capture info %}{% include_relative _installations/{{os}}.md %}{% endcapture %}
+          {{info | markdownify}}
+        {% endif %}
+      </div>
+    {% endfor %}
   </div>
-</div>
+</details>
 
-<div id="install-instructions">
-  <div class="install-os-instructions">Loading...</div>
-  {% for os in layout.operating_systems %}
-    <div id="{{os}}" class="install-os-instructions" style="display: none">
-      {% capture os_i18n %}install_os_{{os}}{% endcapture %}
-      <h3>{{i18n[os_i18n]}}</h3>
-      {% capture exists %}{% file_exists _installations/{{os}}.md %}{% endcapture %}
-      {% if exists == "true" %}
-        {% capture info %}{% include_relative _installations/{{os}}.md %}{% endcapture %}
-        {{info | markdownify}}
-      {% endif %}
-    </div>
-  {% endfor %}
-</div>
+<h2>{{i18n.install_check}}</h2>
 
 <p>
-  {{i18n.install_test}}
+  {{i18n.install_check_details}}
 </p>
 
 {% highlight sh %}
@@ -69,29 +82,3 @@ operating_systems:
 <div class="language-sh highlighter-rouge">
   <pre class="rougeHighlight"><code>yarn --version</code></pre>
 </div>
-
-{% capture issueBody %}
-**Which operating system are you using:**
-
-
-**Please describe the steps you took when trying to install Yarn and what went wrong:**
-
-{% endcapture %}
-{% assign issueBodyEscaped = issueBody | uri_escape %}
-
-{% assign searchHref = "https://github.com/yarnpkg/yarn/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20%22Installation%20Problem%22%20in%3Atitle%20" %}
-{% assign newIssueHref = "https://github.com/yarnpkg/yarn/issues/new?title=Installation%20Problem:%20[title]&body=" | append: issueBodyEscaped %}
-
-<hr class="my-4">
-
-<blockquote>
-  <p>
-    <strong>{{i18n.install_problems_title}}</strong>
-    {{i18n.install_problems_description}}
-  </p>
-  <p>
-    <a class="text-success" href="{{searchHref}}">{{i18n.install_problems_search}}</a>
-    &middot;
-    <a class="text-danger" href="{{newIssueHref}}">{{i18n.install_problems_new_issue}}</a>
-  </p>
-</blockquote>

--- a/_layouts/pages/install.html
+++ b/_layouts/pages/install.html
@@ -1,6 +1,6 @@
 ---
 layout: guide
-hero_subtext: version.html
+hero_subtext: version-with-upgrade-notice.html
 scripts:
   - "/js/build/install.js"
 operating_systems:

--- a/_sass/_news.scss
+++ b/_sass/_news.scss
@@ -1,0 +1,60 @@
+.news-container {
+  position: relative;
+
+  height: 40px;
+
+  padding: 0 1em;
+
+  text-decoration: none;
+  line-height: 40px;
+
+  margin: auto;
+
+  @media (max-width: 760px) {
+    height: auto;
+    line-height: 30px;
+
+    text-align: center;
+  }
+
+  background: #2188b6;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.news-overlay {
+  position: absolute;
+
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+}
+
+.news-inner {
+  position: relative;
+  z-index: 1;
+
+  pointer-events: none;
+
+  a {
+    display: inline-block;
+
+    pointer-events: all;
+
+    color: inherit;
+
+    &:hover {
+      color: #ffffff;
+    }
+  }
+}
+
+.news-line {
+  display: inline-block;
+}
+
+.news-highlight {
+  font-weight: bold;
+
+  color: #ffffff;
+}

--- a/_sass/_news.scss
+++ b/_sass/_news.scss
@@ -21,6 +21,16 @@
   color: rgba(255, 255, 255, 0.8);
 }
 
+.news-container-alert {
+  position: relative;
+
+  height: auto;
+
+  text-decoration: none;
+
+  margin: auto;
+}
+
 .news-overlay {
   position: absolute;
 
@@ -45,6 +55,14 @@
 
     &:hover {
       color: #ffffff;
+    }
+
+    .alert & {
+      color: $link-color;
+
+      &:hover {
+        color: $link-color-hover;
+      }
     }
   }
 }

--- a/css/main.scss
+++ b/css/main.scss
@@ -26,6 +26,7 @@ $npm-red: #c12127;
 
 @import 'bootstrap/scss/bootstrap.scss';
 @import '_base.scss';
+@import '_news.scss';
 @import '_navbar.scss';
 @import '_icons.scss';
 @import '_heros.scss';

--- a/css/main.scss
+++ b/css/main.scss
@@ -21,6 +21,7 @@ $brand-primary: $yarn-blue;
 $progress-bar-color: $brand-primary;
 
 $link-color: saturate(darken($brand-primary, 8%), 20%);
+$link-color-hover: saturate(darken($brand-primary, 30%), 20%);
 
 $npm-red: #c12127;
 

--- a/js/src/install.js
+++ b/js/src/install.js
@@ -53,7 +53,7 @@ function getNightlyVersionNumber() {
     .then(res => res.text())
     .then(version => {
       document.getElementById('nightly-version').innerText =
-        'Nightly (' + version + ')';
+        'Classic Nightly (' + version + ')';
     });
 }
 

--- a/lang/en/docs/_installations/alternatives.md
+++ b/lang/en/docs/_installations/alternatives.md
@@ -8,38 +8,6 @@ recommended to install Yarn via our packages instead.
 <!-- prettier-ignore -->
 {% include_relative _installations/tarball.md %}
 
-#### Install via npm
-
-<div class="install-only-stable install-only-rc" markdown="1">
-  > **Note:** Installation of Yarn via npm is generally not recommended.
-  > When installing Yarn with Node-based package managers, the package is not signed,
-  > and the only integrity check performed is a basic SHA1 hash, which is a
-  > security risk when installing system-wide apps.
-  >
-  > For these reasons, it is highly recommended that you install Yarn through the
-  > installation method best suited to your operating system.
-
-You can also install Yarn through the [npm package manager](http://npmjs.org/)
-if you already have it installed. If you already have
-[Node.js](https://nodejs.org/) installed then you should already have npm.
-
-Once you have npm installed you can run:
-
-<div class="install-only-stable" markdown="1">
-```sh
-npm install --global yarn
-```
-</div>
-<div class="install-only-rc" markdown="1">
-```sh
-npm install --global yarn@rc
-```
-</div>
-</div>
-<div class="install-only-nightly" markdown="1">
-  Nightly builds of Yarn are not available via npm.
-</div>
-
 ### Path Setup
 
 #### Unix/Linux/macOS

--- a/lang/en/docs/_installations/npm.md
+++ b/lang/en/docs/_installations/npm.md
@@ -1,0 +1,9 @@
+## Install via npm
+
+It is recommended to install Yarn through the [npm package manager](http://npmjs.org/), which comes bundled with [Node.js](https://nodejs.org/) when you install it on your system.
+
+Once you have npm installed you can run the following both to **install** and **upgrade** Yarn:
+
+```sh
+npm install --global yarn
+```

--- a/lang/en/docs/cli/self-update.md
+++ b/lang/en/docs/cli/self-update.md
@@ -8,6 +8,10 @@ layout: guide
 
 ##### `yarn self-update` <a class="toc" id="toc-yarn-self-update" href="#toc-yarn-self-update"></a>
 
-_Note: `self-update` is not available. See [policies](https://yarnpkg.com/lang/en/docs/cli/policies/#toc-policies-set-version) for enforcing versions within a project_
+_**Important**: `self-update` is not available. See [policies](https://yarnpkg.com/lang/en/docs/cli/policies/#toc-policies-set-version) for enforcing versions within a project_
 
-In order to update your version of Yarn, run `curl --compressed -o- -L https://yarnpkg.com/install.sh | bash`
+In order to update your version of Yarn, you can run one of the following commands:
+
+- `npm install --global yarn` - if you've installed Yarn via npm (recommended)
+- `curl --compressed -o- -L - https://yarnpkg.com/install.sh | bash` if you're on Unix
+- otherwise, check the docs of the installer you've used to install Yarn


### PR DESCRIPTION
The time for us to add some v2+ upgrade notices has finally come.

This PR adds:
- a migration banner
- a migrate button on the homepage
- updates the installation page to recommend installation via npm
- updates the self-update docs a bit
- adds an update notice to the installation page
- a few other small changes that I've discussed with @arcanis and the rest of the team