### PR TITLE
yarn audit: add example how to use multiple groups

### DIFF
--- a/lang/en/docs/cli/audit.md
+++ b/lang/en/docs/cli/audit.md
@@ -37,4 +37,17 @@ Applying the level flag will limit the audit table to vulnerabilities of the cor
 
 ##### `yarn audit [--groups group_name ...]` <a class="toc" id="toc-yarn-add" href="#toc-yarn-add"></a>
 
-Applying the groups flag will limit the audit table to vulnerabilities of the corresponding dependency groups (e.g dependencies,devDependencies).
+Applying the groups flag will limit the audit table to vulnerabilities of the corresponding dependency groups (e.g dependencies, devDependencies).
+
+Example for auditing only one group:
+
+```sh
+$ yarn audit --groups dependencies
+```
+
+Or multiple groups:
+
+```sh
+$ yarn audit --groups "dependencies devDependencies"
+```
+


### PR DESCRIPTION
It was a bit misleading until now how exactly to use the `--groups` parameter when you want to audit multiple groups at once.  
I added two examples that hopefully clear things up...

see https://github.com/yarnpkg/yarn/issues/8495