### PR TITLE
Carify dependency direction in link doc

### DIFF
--- a/lang/en/docs/cli/link.md
+++ b/lang/en/docs/cli/link.md
@@ -16,7 +16,7 @@ There are two commands to facilitate this workflow:
 
 ##### `yarn link` (in package you want to link) <a class="toc" id="toc-yarn-link-in-package-you-want-to-link" href="#toc-yarn-link-in-package-you-want-to-link"></a>
 
-This command is run in the package folder you'd like to link. For example if you
+This command is run in the package folder you'd like to consume. For example if you
 are working on `react` and would like to use your local version to debug a
 problem in `react-relay`, simply run `yarn link` inside of the `react` project.
 


### PR DESCRIPTION
'linking' is something of a symmetric verb. Linking packages A and B doesn't imply a specific hierarchy.

Replacing one instance of *link* here with *consume* make the direction of the dependency more obvious on first read.