### PR TITLE
yarnpkg.com --> classic.yarnpkg.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Yarn
 description: > # this means to ignore newlines until "baseurl:"
   Fast, reliable, and secure dependency management.
 baseurl: ""
-url: "https://yarnpkg.com"
+url: "https://classic.yarnpkg.com"
 twitter_username: yarnpkg
 github_username:  yarnpkg
 

--- a/js/src/components/Details.js
+++ b/js/src/components/Details.js
@@ -22,7 +22,7 @@ const readmeErrorMessage = 'ERROR: No README data found!';
 
 function setHead({ name, description }) {
   const head = document.querySelector('head');
-  const permalink = `https://yarnpkg.com${packageLink(name)}`;
+  const permalink = `https://classic.yarnpkg.com${packageLink(name)}`;
   head.querySelector('meta[property="og:title"]').setAttribute('content', name);
   document.title = `${name} | Yarn`;
   head


### PR DESCRIPTION
See yarnpkg/berry#3425 for motivation. This will update `<link rel="canonical">`, so Google Search will show "classic" URL. Also updates `<meta property="og:url">`.

`_config.yml `: This change will add `classic` subdomain to `<link rel="canonical">` & `<meta property="og:url">` for most pages, via [_layouts/default.html](https://github.com/yarnpkg/website/blob/5be62ee/_layouts/default.html)

`js/src/components/Details.js`: This change will update `<link rel="canonical">` & `<meta property="og:url">` for  "Package detail" pages, e.g. https://classic.yarnpkg.com/en/package/Babel

Note: I haven't yet attempted to test these changes locally. I'm willing to do so if there is any uncertainty as to the outcome. Just took a look at the "deploy preview" and it looks good.