### PR TITLE
Updates the versions on the website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ github_username:  yarnpkg
 #
 # Thanks!
 ###
-latest_version: 1.22.5
-latest_rc_version: 1.22.0
+latest_version: 1.22.13
+latest_rc_version: 1.22.13
 
 # Whether to show the RC version on the site. Set this to false if the latest
 # stable version is newer than the RC (ie. if an RC has not been released since


### PR DESCRIPTION
We were falling quite behind in patch releases since the automated pipeline got issues. Updating to the newly released [1.12.13](https://github.com/yarnpkg/yarn/releases/tag/v1.22.13).