### PR TITLE
Promote 1.22.17 on 1.x landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,17 +7,8 @@ url: "https://classic.yarnpkg.com"
 twitter_username: yarnpkg
 github_username:  yarnpkg
 
-###
-# Hi there! I see you're trying to update the latest_version to whatever
-# it currently is. Please don't worry about it, the team will handle it.
-#
-# If it appears to have fallen behind, then we have decided to hold it
-# back for now, we have not forgotten about it.
-#
-# Thanks!
-###
-latest_version: 1.22.15
-latest_rc_version: 1.22.15
+latest_version: 1.22.17
+latest_rc_version: 1.22.17
 
 # Whether to show the RC version on the site. Set this to false if the latest
 # stable version is newer than the RC (ie. if an RC has not been released since


### PR DESCRIPTION
It looks like this comment saying to NOT update the yarn version is 5 years old: https://github.com/yarnpkg/website/blame/d0699c5dc13f80f0453d2e2b153b0cf6694320b8/_config.yml

Also, 2nd to last update here: https://github.com/yarnpkg/website/pull/1136
@arcanis suggests that:
> We were falling quite behind in patch releases since the automated pipeline got issues.

Latest version on npm registry is 1.22.17.
1.22.17 has 1.6 million more downloads than 1.22.15: https://www.npmjs.com/package/yarn?activeTab=versions
1.22.17 is merged to 1.22-stable branch: https://github.com/yarnpkg/yarn/tree/1.22-stable
1.22.17 has been released as latest version for longer than 1.22.15.
1.22.17 was released 2 weeks after 1.22.15.