### PR TITLE
fix(create): explicitly indicate the bin name

### DIFF
--- a/lang/en/docs/cli/create.md
+++ b/lang/en/docs/cli/create.md
@@ -14,7 +14,7 @@ This command is a shorthand that helps you do two things at once:
 
 - Install `create-<starter-kit-package>` globally, or update the package to the
   latest version if it already exists
-- Run the executable located in the `bin` field of the starter kit’s `package.json`,
+- Run the `create-<starter-kit-package>` executable located in the `bin` field of the starter kit’s `package.json`,
   forwarding any `<args>` to it
 
 For example, `yarn create react-app my-app` is equivalent to:


### PR DESCRIPTION
In order for `yarn create` to work, the `bin` name in the starter kit’s `package.json` needs to be `create-<starter-kit-package>`: https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/create.js#L71