### PR TITLE
Support linking with older yarn versions

### DIFF
--- a/lang/en/docs/cli/link.md
+++ b/lang/en/docs/cli/link.md
@@ -20,6 +20,12 @@ This command is run in the package folder you'd like to consume. For example if 
 are working on `react` and would like to use your local version to debug a
 problem in `react-relay`, simply run `yarn link` inside of the `react` project.
 
+In case if you want to link yarn 3+ project into project which uses older versions of yarn
+
+```sh
+$ YARN_IGNORE_PATH=1 yarn link
+```
+
 ##### `yarn link [package...]`<a class="toc" id="toc-yarn-link-package" href="#toc-yarn-link-package"></a>
 
 Use `yarn link [package]` to link another package that you'd like to test into


### PR DESCRIPTION
We have two project which use yarn, the website uses yarn 1 and the package uses yarn 3.

We want to be able to test & develop package locally and have live updates for the main react app.

I found this pease missing how to support integration with legacy projects.

[related issue](https://github.com/yarnpkg/berry/issues/90)