### PR TITLE
Provide best-practice guidance for managing yarn.lock

### DIFF
--- a/lang/en/docs/cli/upgrade.md
+++ b/lang/en/docs/cli/upgrade.md
@@ -93,3 +93,10 @@ Examples:
 yarn upgrade --scope @angular
 yarn upgrade -S @angular
 ```
+
+Note:
+
+Users should be aware that when yarn.lock is present, indirect dependencies
+will only be updated by `yarn upgrade` without a package name.  In order to
+maintain the security of their applications, users should ensure that `yarn
+upgrade` is a regular part of their development process.


### PR DESCRIPTION
In order to ensure that users don't have long-lived security vulnerabilities in their applications, it would be very helpful to provide direct, specific guidance on updating indirect dependencies, which can otherwise remain versioned locked for long periods of time.