### PR TITLE
Create missing docs for yarn exec

### DIFF
--- a/lang/en/docs/cli/exec.md
+++ b/lang/en/docs/cli/exec.md
@@ -1,0 +1,18 @@
+---
+id: docs_cli_exec
+guide: docs_cli
+layout: guide
+---
+
+{% include vars.html %}
+
+<p class="lead">Executes a shell script.</p>
+
+##### `yarn exec` <a class="toc" id="toc-yarn-exec" href="#toc-yarn-exec"></a>
+
+This command executes a shell script.
+
+```sh
+$ yarn exec echo test message
+test message
+```


### PR DESCRIPTION
Closes #1053

`yarn` implementation has links to this pages (e.g. via https://github.com/yarnpkg/yarn/blob/3119382885ea373d3c13d6a846de743eca8c914b/src/cli/commands/index.js#L7), but it seems that this page was never added