### PR TITLE
Remove polyfill.io script

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,6 @@
       <link rel="stylesheet" href="{{stylesheet}}" />
     {% endfor %}
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}">
-    <script src="https://cdn.polyfill.io/v2/polyfill.js?unknown=polyfill&excludes=Element"></script>
     <meta name="google-site-verification" content="DIcCyEkVaGHm864NWzItnt2n6Gg7hz3l47RBIRyxvcQ" />
   </head>
   <body>


### PR DESCRIPTION
Polyfill.io has been compromised and should not be used.

https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/ https://github.com/formatjs/formatjs/issues/4363
https://github.com/sampotts/plyr/issues/2799
https://github.com/remix-run/react-router/issues/11733